### PR TITLE
添加 数据库连接 插件中TiDB的支持

### DIFF
--- a/modules/tool/packages/databaseConnection/config.ts
+++ b/modules/tool/packages/databaseConnection/config.ts
@@ -42,6 +42,10 @@ export default defineTool({
               {
                 label: 'Microsoft SQL Server',
                 value: 'Microsoft SQL Server'
+              },
+              {
+                label: 'TiDB',
+                value: 'TiDB'
               }
             ]
           },

--- a/modules/tool/packages/databaseConnection/src/index.ts
+++ b/modules/tool/packages/databaseConnection/src/index.ts
@@ -4,7 +4,7 @@ import mysql from 'mysql2/promise'; // MySQL 客户端
 import mssql from 'mssql'; // SQL Server 客户端
 
 // const supportedDatabaseTypes = ['PostgreSQL', 'MySQL', 'Microsoft SQL Server'];
-const supportedDatabaseTypes = z.enum(['PostgreSQL', 'MySQL', 'Microsoft SQL Server']);
+const supportedDatabaseTypes = z.enum(['PostgreSQL', 'MySQL', 'TiDB', 'Microsoft SQL Server']);
 
 export const InputType = z
   .object({
@@ -59,6 +59,19 @@ export async function tool({
         user,
         password,
         connectTimeout: 30000
+      });
+      const [rows] = await connection.execute(sql);
+      result = rows;
+      await connection.end();
+    } else if (databaseType === 'TiDB') {
+      const connection = await mysql.createConnection({
+        host,
+        port,
+        database: databaseName,
+        user,
+        password,
+        connectTimeout: 30000,
+        enableKeepAlive: false
       });
 
       const [rows] = await connection.execute(sql);


### PR DESCRIPTION
### 开发环境
    Tidb 版本: 6.12

###  Fastgpt中效果截图：
![32d057db-a370-4ced-8513-8df2a34d2f7c](https://github.com/user-attachments/assets/cf14ec18-822c-41e2-9711-3fdb495479b8)
![13f60f30-564c-4b89-b4e0-d626d938a76f](https://github.com/user-attachments/assets/3f99b195-c39e-461a-b0f5-db410b097db9)

### 代码说明
```
      const connection = await mysql.createConnection({  # 使用兼容mysql客户端
        host,
        port,
        database: databaseName,
        user,
        password,
        connectTimeout: 30000,
        enableKeepAlive: false   # 关闭存活保持
      });
```
