### PR TITLE
feat: add vllm backend support for MinerU parser

### DIFF
--- a/modules/tool/packages/mineru/children/parseLocal/config.ts
+++ b/modules/tool/packages/mineru/children/parseLocal/config.ts
@@ -90,7 +90,10 @@ export default defineTool({
             { label: 'pipeline', value: 'pipeline' },
             { label: 'vlm-transformers', value: 'vlm-transformers' },
             { label: 'vlm-sglang-engine', value: 'vlm-sglang-engine' },
-            { label: 'vlm-sglang-client', value: 'vlm-sglang-client' }
+            { label: 'vlm-sglang-client', value: 'vlm-sglang-client' },
+            { label: 'vllm-async-engine', value: 'vllm-async-engine' },
+            { label: 'vllm-engine', value: 'vllm-engine' },
+            { label: 'http-client', value: 'http-client' }
           ],
           defaultValue: 'pipeline'
         },


### PR DESCRIPTION
Added new backend options:
- vllm-async-engine
- vllm-engine
- http-client

These options extend the existing pipeline and sglang backends to support more deployment scenarios.