### PR TITLE
fix: oracle db object serialization

### DIFF
--- a/modules/tool/packages/dbops/children/oracle/src/index.ts
+++ b/modules/tool/packages/dbops/children/oracle/src/index.ts
@@ -1,25 +1,6 @@
 import type { OracleInputType, SQLDbOutputType } from '@tool/packages/dbops/types';
 import oracle from 'oracledb';
 
-function refine(result: any) {
-  if (!result.metaData || !result.rows) {
-    throw new Error('Invalid result: metaData or rows missing');
-  }
-
-  const columnNames = result.metaData.map((column: any) => column.name);
-
-  return result.rows.map((row: any, index: number) => {
-    if (row.length !== columnNames.length) {
-      throw new Error(`Row ${index} length does not match metaData length`);
-    }
-    const data: any = {};
-    columnNames.forEach((name: any, index: number) => {
-      data[name] = row[index];
-    });
-    return data;
-  });
-}
-
 export async function main({
   sql: _sql,
   connectString,
@@ -41,7 +22,10 @@ export async function main({
     const sql = await pool.getConnection();
     const result = await sql.execute(_sql);
     await sql.close();
-    return { result };
+    await pool.close();
+    return {
+      result: JSON.parse(JSON.stringify(result))
+    };
   } catch (error: unknown) {
     if (error instanceof Error) {
       return Promise.reject(Error(`Oracle SQL execution error: ${error.message}`));


### PR DESCRIPTION
due to oracle db result, there might be some object which can't be serialized, such as `BigInt`, `Buffer` etc.

so, make a safe result instead

`JSON.parse(JSON.stringify(result));`