### PR TITLE
feat(model): add Doubao 2.0 model presets

### DIFF
--- a/modules/model/provider/Doubao/index.ts
+++ b/modules/model/provider/Doubao/index.ts
@@ -5,6 +5,39 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'doubao-seed-2-0-pro-260215',
+      maxContext: 256000,
+      maxTokens: 128000,
+      quoteMaxToken: 256000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'doubao-seed-2-0-lite-260215',
+      maxContext: 256000,
+      maxTokens: 128000,
+      quoteMaxToken: 256000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'doubao-seed-2-0-mini-260215',
+      maxContext: 256000,
+      maxTokens: 128000,
+      quoteMaxToken: 256000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'doubao-seed-1-8-251228',
       maxContext: 220000,
       maxTokens: 16000,


### PR DESCRIPTION
## What
Add Doubao-Seed-2.0 series model presets, released on 2025-02-14.

## Models Added
| Model ID | Description |
|---|---|
| `doubao-seed-2-0-pro-260215` | Flagship Agent model for deep reasoning & long-chain task execution |
| `doubao-seed-2-0-lite-260215` | Balanced performance and cost, surpasses Doubao 1.8 |
| `doubao-seed-2-0-mini-260215` | Low latency, high concurrency, cost-sensitive scenarios |
| `doubao-seed-2-0-code-preview-260215` | Optimized for coding scenarios (works with TRAE) |

## Specs (all 2.0 models)
- Context window: 256k
- Max input: 256k
- Max output: 128k (default 4k)
- Vision (multimodal understanding): ✅
- Reasoning (deep thinking): ✅
- Tool calling: ✅

## Reference
- [Volcengine Model List](https://www.volcengine.com/docs/82379/1330310)
- [Doubao 2.0 Announcement](https://www.volcengine.com/docs/82379/2123228)