### PR TITLE
feat(model): add Qwen3.5-Plus model preset

### DIFF
--- a/modules/model/provider/Qwen/index.ts
+++ b/modules/model/provider/Qwen/index.ts
@@ -34,6 +34,7 @@ const models: ProviderConfigType = {
       maxTokens: 8000,
       quoteMaxToken: 120000,
       maxTemperature: 1,
+      responseFormatList: ['text', 'json_object'],
       vision: true,
       reasoning: false,
       toolChoice: false
@@ -45,7 +46,7 @@ const models: ProviderConfigType = {
       maxTokens: 64000,
       quoteMaxToken: 256000,
       maxTemperature: 1,
-      responseFormatList: ['text', 'json_object'],
+      responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: false,
       reasoning: false,
       toolChoice: true
@@ -57,7 +58,7 @@ const models: ProviderConfigType = {
       maxTokens: 32000,
       quoteMaxToken: 1000000,
       maxTemperature: 1,
-      responseFormatList: ['text', 'json_object'],
+      responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: false,
       reasoning: false,
       toolChoice: true
@@ -69,6 +70,7 @@ const models: ProviderConfigType = {
       maxTokens: 8000,
       quoteMaxToken: 120000,
       maxTemperature: 1,
+      responseFormatList: ['text', 'json_object'],
       vision: true,
       reasoning: false,
       toolChoice: false
@@ -92,7 +94,7 @@ const models: ProviderConfigType = {
       maxTokens: 32000,
       quoteMaxToken: 1000000,
       maxTemperature: 1,
-      responseFormatList: ['text', 'json_object'],
+      responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: false,
       reasoning: false,
       toolChoice: true
@@ -119,7 +121,7 @@ const models: ProviderConfigType = {
       maxTokens: 8000,
       quoteMaxToken: 20000,
       maxTemperature: 1,
-      responseFormatList: ['text'],
+      responseFormatList: ['text', 'json_object'],
       vision: true,
       reasoning: false,
       toolChoice: true
@@ -131,7 +133,7 @@ const models: ProviderConfigType = {
       maxTokens: 8000,
       quoteMaxToken: 20000,
       maxTemperature: 1,
-      responseFormatList: ['text'],
+      responseFormatList: ['text', 'json_object'],
       vision: true,
       reasoning: false,
       toolChoice: true
@@ -357,6 +359,7 @@ const models: ProviderConfigType = {
       maxTokens: 6000,
       quoteMaxToken: 10000000,
       maxTemperature: 1,
+      responseFormatList: ['text', 'json_object'],
       vision: false,
       reasoning: false,
       toolChoice: false,


### PR DESCRIPTION
Add Qwen3.5-Plus (qwen3.5-plus) model preset to Qwen provider.

## Model Info (from Alibaba Cloud official docs)
- **Model**: qwen3.5-plus
- **Context**: 1,000,000 tokens
- **Max Output**: 65,536 tokens
- **Max Thinking Chain**: 81,920 tokens
- **Vision**: ✅ (text + image + video input)
- **Reasoning**: ✅ (thinking mode enabled by default)
- **Tool Choice**: ✅
- **Response Format**: text, json_object

Qwen3.5-Plus achieves comparable performance to Qwen3-Max on pure text tasks with better cost efficiency, and significantly improves multimodal capabilities over the Qwen3-VL series.