### PR TITLE
fix(model): kimi-k2.5 disable temperature config

### DIFF
--- a/modules/model/provider/Moonshot/index.ts
+++ b/modules/model/provider/Moonshot/index.ts
@@ -9,11 +9,12 @@ const models: ProviderConfigType = {
       maxContext: 256000,
       maxTokens: 32000,
       quoteMaxToken: 250000,
-      maxTemperature: 1,
+      maxTemperature: null,
       responseFormatList: ['text', 'json_object'],
       vision: false,
       reasoning: true,
       toolChoice: true,
+      showTopP: false,
       defaultConfig: {
         thinking: {
           type: 'enabled'


### PR DESCRIPTION
kimi-k2.5 does not support temperature parameter.

- Set `maxTemperature` to `null`
- Add `showTopP: false` to hide TopP control