### PR TITLE
feat: add Gemini 3.1 models 

### DIFF
--- a/modules/model/provider/Gemini/index.ts
+++ b/modules/model/provider/Gemini/index.ts
@@ -5,6 +5,28 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'gemini-3.1-flash-lite-preview',
+      maxContext: 1000000,
+      maxTokens: 64000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gemini-3.1-pro-preview',
+      maxContext: 1000000,
+      maxTokens: 64000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gemini-3-flash-preview',
       maxContext: 1024000,
       maxTokens: 64000,


### PR DESCRIPTION
## Changes

- Add **gemini-3.1-flash-lite-preview** (released March 3, 2026)
- Add **gemini-3.1-pro-preview** (released February 19, 2026)

## Model Details

### Gemini 3.1 Flash-Lite Preview
- Context: 1M tokens
- Max tokens: 64k
- Vision: ✅
- Tool choice: ✅
- Release date: March 3, 2026

### Gemini 3.1 Pro Preview
- Context: 1M tokens
- Max tokens: 64k
- Vision: ✅
- Tool choice: ✅
- Release date: February 19, 2026

## References
- [Gemini 3.1 Pro announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/)
- [Gemini 3.1 Flash-Lite announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-lite/)
- [Google Cloud Documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro)