### PR TITLE
feat: add gpt-5.4 and gpt-5.4-pro models

### DIFF
--- a/modules/model/provider/OpenAI/index.ts
+++ b/modules/model/provider/OpenAI/index.ts
@@ -5,6 +5,30 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'gpt-5.4',
+      maxContext: 250000,
+      maxTokens: 128000,
+      quoteMaxToken: 200000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gpt-5.4-pro',
+      maxContext: 250000,
+      maxTokens: 128000,
+      quoteMaxToken: 200000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gpt-5.2',
       maxContext: 250000,
       maxTokens: 128000,


### PR DESCRIPTION
Add OpenAI's latest flagship models:

- **gpt-5.4**: 250K context, 128K output, vision, json_schema support
- **gpt-5.4-pro**: 250K context, 128K output, vision, json_schema support (enhanced reasoning version)

These are OpenAI's most capable models for professional work as of March 2026.