### PR TITLE
fix(model): refresh Gemini provider presets

### DIFF
--- a/modules/model/provider/Gemini/index.ts
+++ b/modules/model/provider/Gemini/index.ts
@@ -41,18 +41,6 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'gemini-3.1-flash-lite-preview',
-      maxContext: 1000000,
-      maxTokens: 64000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'gemini-3.1-pro-preview',
       maxContext: 1000000,
       maxTokens: 64000,
@@ -148,34 +136,16 @@ const models: ProviderConfigType = {
       toolChoice: true
     },
     {
-      type: ModelTypeEnum.llm,
-      model: 'gemini-1.5-flash',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 60000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'gemini-1.5-pro',
-      maxContext: 2000000,
-      maxTokens: 8000,
-      quoteMaxToken: 60000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
+      type: ModelTypeEnum.embedding,
+      model: 'gemini-embedding-2',
+      defaultToken: 512,
+      maxToken: 8192
     },
     {
       type: ModelTypeEnum.embedding,
-      model: 'text-embedding-004',
+      model: 'gemini-embedding-001',
       defaultToken: 512,
-      maxToken: 2000
+      maxToken: 2048
     },
     {
       type: ModelTypeEnum.embedding,


### PR DESCRIPTION
## Summary
- Add current Gemini embedding model IDs `gemini-embedding-2` and `gemini-embedding-001`.
- Remove Gemini presets that official docs mark as shut down or reaching shutdown date: `gemini-3.1-flash-lite-preview`, `gemini-1.5-flash`, `gemini-1.5-pro`, and `text-embedding-004`.

## Evidence
- https://ai.google.dev/gemini-api/docs/models
- https://ai.google.dev/gemini-api/docs/deprecations
- https://ai.google.dev/gemini-api/docs/embeddings

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /private/tmp/gemini-provider-plan-20260525.json --dry-run`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Gemini`
- `git diff --check`
- `node_modules/.bin/tsc --noEmit`

`bun run test -- modules/model/provider/Gemini` found no matching test files. Repo-wide `bun run test` was attempted and failed on existing temp-worktree alias resolution plus Feishu network authentication (`open.feishu.cn` DNS), unrelated to this provider-only change.