### PR TITLE
feat(model): refresh OpenAI provider presets

### DIFF
--- a/modules/model/provider/OpenAI/index.ts
+++ b/modules/model/provider/OpenAI/index.ts
@@ -157,6 +157,31 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'gpt-5.2-pro',
+      maxContext: 400000,
+      maxTokens: 128000,
+      quoteMaxToken: 350000,
+      maxTemperature: null,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gpt-5.2-chat-latest',
+      maxContext: 128000,
+      maxTokens: 16384,
+      quoteMaxToken: 128000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gpt-5.1',
       maxContext: 400000,
       maxTokens: 128000,
@@ -199,6 +224,31 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'gpt-5-pro',
+      maxContext: 400000,
+      maxTokens: 272000,
+      quoteMaxToken: 350000,
+      maxTemperature: null,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gpt-5-chat-latest',
+      maxContext: 128000,
+      maxTokens: 16384,
+      quoteMaxToken: 128000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gpt-5-mini',
       maxContext: 400000,
       maxTokens: 128000,
@@ -224,21 +274,6 @@ const models: ProviderConfigType = {
       vision: true,
       reasoning: true,
       reasoningEffort: true,
-      toolChoice: true,
-      fieldMap: {
-        max_tokens: 'max_completion_tokens'
-      }
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'gpt-5-chat',
-      maxContext: 128000,
-      maxTokens: 16000,
-      quoteMaxToken: 128000,
-      maxTemperature: 1.2,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
       toolChoice: true,
       fieldMap: {
         max_tokens: 'max_completion_tokens'


### PR DESCRIPTION
## Summary\n- Add OpenAI primary model presets for gpt-5.2-pro, gpt-5.2-chat-latest, gpt-5-pro, and gpt-5-chat-latest.\n- Replace the undocumented gpt-5-chat preset with the official gpt-5-chat-latest alias.\n- Audited OpenAI against official model/pricing docs; checked Gemini, Grok, and Qwen with no local changes needed.\n\n## Sources\n- https://platform.openai.com/docs/models\n- https://platform.openai.com/docs/pricing\n- https://ai.google.dev/gemini-api/docs/models\n- https://docs.x.ai/docs/models/\n- https://help.aliyun.com/zh/model-studio/getting-started/models\n\n## Validation\n- PASS: git diff --check\n- PASS: bunx prettier --check modules/model/provider/OpenAI/index.ts\n- PASS: OpenAI provider schema parse via Bun (32 models)\n- FAIL (pre-existing environment): bun run test fails on missing Vitest alias/bun:test handling and Feishu credentials\n- FAIL (pre-existing environment): bun tsc --noEmit fails on missing optional package dependencies/types such as node-fetch, xml2js, database drivers, and doc export libs