### PR TITLE
feat(model): add Qwen3.7 Max preset

### DIFF
--- a/.github/workflows/preview-push.yml
+++ b/.github/workflows/preview-push.yml
@@ -59,6 +59,11 @@ jobs:
             ${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-plugin-pr:${{ steps.pr.outputs.sha }}
           docker push ${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-plugin-pr:${{ steps.pr.outputs.sha }}
 
+      - name: Format preview timestamp
+        id: preview_time
+        run: |
+          echo "value=$(TZ='Asia/Shanghai' date '+%Y-%m-%d %H:%M:%S (UTC+8)')" >> "$GITHUB_OUTPUT"
+
       - name: Add PR comment on success
         if: success() && steps.pr.outputs.number != ''
         uses: actions/github-script@v7
@@ -86,6 +91,8 @@ jobs:
 
             **Changed packages:**
             ${{ steps.pr.outputs.package_changes || 'None' }}
+
+            🕒 Time: ${{ steps.preview_time.outputs.value }}
             `;
 
             if (existingComment) {
@@ -103,4 +110,3 @@ jobs:
                 body: commentBody
               });
             }
-

--- a/modules/model/provider/Qwen/index.ts
+++ b/modules/model/provider/Qwen/index.ts
@@ -10,6 +10,19 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'qwen3.7-max',
+      maxContext: 1000000,
+      maxTokens: 64000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object', 'json_schema'],
+      vision: false,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'qwen3.6-max-preview',
       maxContext: 260000,
       maxTokens: 64000,

--- a/modules/workflow/templates/Chinese.json
+++ b/modules/workflow/templates/Chinese.json
@@ -39,7 +39,7 @@
           },
           {
             "key": "questionGuide",
-            "valueType": "any",
+            "valueType": "object",
             "renderTypeList": ["hidden"],
             "label": "core.app.Question Guide",
             "value": {
@@ -336,6 +336,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "valueDesc": "",
@@ -346,6 +347,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({svg_str}){\n\n    // 使用正则表达式匹配代码块中的内容\n    const match = svg_str.match(/```[\\w]*\\n([\\s\\S]*?)```/);\n\n    if (!match) {\n        // 如果没有匹配到代码块，返回一个错误信息或空结果\n        return {\n            result: null,\n            error: \"未找到有效的代码块标记。\"\n        };\n    }\n\n    // 提取代码块中的 SVG 内容\n    const extractedSvg = match[1].trim();\n    \n    const base64 = strToBase64(extractedSvg,'data:image/svg+xml;base64,')\n\n    return {\n        result: base64\n    }\n}",
             "valueDesc": "",

--- a/modules/workflow/templates/TranslateRobot.json
+++ b/modules/workflow/templates/TranslateRobot.json
@@ -35,7 +35,7 @@
           },
           {
             "key": "questionGuide",
-            "valueType": "any",
+            "valueType": "object",
             "renderTypeList": ["hidden"],
             "label": "core.app.Question Guide",
             "value": {
@@ -270,12 +270,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({data1}) {\n    const codeBlocks = data1.match(/```[\\s\\S]*?```/g);\n\n    if (codeBlocks && codeBlocks.length > 0) {\n        const lastCodeBlock = codeBlocks[codeBlocks.length - 1];\n        const cleanedCodeBlock = lastCodeBlock.replace(/```[a-zA-Z]*|```/g, '').trim();\n        \n        return {\n            result: cleanedCodeBlock\n        };\n    }\n\n    return {\n        result: '未截取到代码块内容'\n    };\n}\n"
           },

--- a/modules/workflow/templates/githubIssue.json
+++ b/modules/workflow/templates/githubIssue.json
@@ -170,7 +170,7 @@
             "renderTypeList": ["custom"],
             "valueType": "string",
             "label": "",
-            "value": "function main() {\n  const date = new Date();\n  date.setDate(date.getDate() - 3);\n  const day = date.getDate();\n  const month = date.getMonth() + 1;\n  const year = date.getFullYear();\n  const hours = date.getHours();\n  const minutes = date.getMinutes();\n\n  return {\n    date: `${year}-${month}-${day}T${hours}:${minutes}:000Z`,\n  }\n }",
+            "value": "function main() {\n  const date = new Date();\n  date.setDate(date.getDate() - 1);\n  const day = date.getDate();\n  const month = date.getMonth() + 1;\n  const year = date.getFullYear();\n  const hours = date.getHours();\n  const minutes = date.getMinutes();\n\n  return {\n    date: `${year}-${month}-${day}T${hours}:${minutes}:000Z`,\n  }\n }",
             "valueDesc": "",
             "description": "",
             "debugLabel": "",

--- a/modules/workflow/templates/githubIssue.json
+++ b/modules/workflow/templates/githubIssue.json
@@ -39,7 +39,7 @@
           },
           {
             "key": "questionGuide",
-            "valueType": "hidden",
+            "valueType": "object",
             "renderTypeList": ["hidden"],
             "label": "core.app.Question Guide",
             "value": {
@@ -157,6 +157,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "valueDesc": "",
@@ -167,6 +168,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main() {\n  const date = new Date();\n  date.setDate(date.getDate() - 3);\n  const day = date.getDate();\n  const month = date.getMonth() + 1;\n  const year = date.getFullYear();\n  const hours = date.getHours();\n  const minutes = date.getMinutes();\n\n  return {\n    date: `${year}-${month}-${day}T${hours}:${minutes}:000Z`,\n  }\n }",
             "valueDesc": "",
@@ -516,6 +518,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "valueDesc": "",
@@ -526,6 +529,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({res}) {\n    const issues = JSON.parse(res);\n    const ret = [];\n    for(const issue of issues) {\n        if (issue.pull_request) continue;\n        ret.push({\n            title: issue.title,\n            body: issue.body,\n            url: issue.html_url\n        })\n    }\n\n    return {\n        ret: JSON.stringify(ret)\n    }\n}",
             "valueDesc": "",

--- a/modules/workflow/templates/google.json
+++ b/modules/workflow/templates/google.json
@@ -35,7 +35,7 @@
           },
           {
             "key": "questionGuide",
-            "valueType": "any",
+            "valueType": "object",
             "renderTypeList": ["hidden"],
             "label": "core.app.Question Guide",
             "value": {
@@ -371,12 +371,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({data}){\n    const result = data.items.map((item) => ({\n      title: item.title,\n      link: item.link,\n      snippet: item.snippet\n    }))\n    return { prompt: JSON.stringify(result) }\n}"
           }

--- a/modules/workflow/templates/longTranslate.json
+++ b/modules/workflow/templates/longTranslate.json
@@ -39,7 +39,7 @@
           },
           {
             "key": "questionGuide",
-            "valueType": "any",
+            "valueType": "object",
             "renderTypeList": ["hidden"],
             "label": "core.app.Question Guide",
             "value": {
@@ -379,6 +379,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "debugLabel": "",
@@ -387,6 +388,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({chunks, doc_chunks, currentChunk}){\n    let new_chunks = doc_chunks || chunks\n    const findIndex = new_chunks.findIndex((item) => item ===currentChunk)\n    \n    return {\n        isEnd: new_chunks.length-1 === findIndex,\n        i: findIndex + 1,\n    }\n}",
             "debugLabel": "",
@@ -591,6 +593,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "debugLabel": "",
@@ -599,6 +602,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({source_text_chunks, source_doc_text_chunks, i=0}){\n    let chunks = source_doc_text_chunks || source_text_chunks;\n    let before = chunks.slice(0, i).join(\"\");\n    let current = \" <TRANSLATE_THIS>\" + chunks[i] + \"</TRANSLATE_THIS>\";\n    let after = chunks.slice(i + 1).join(\"\");\n    let tagged_text = before + current + after;\n\n    return {\n        tagged_text,\n        chunk_to_translate: chunks[i],\n    }\n}",
             "debugLabel": "",
@@ -807,6 +811,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "debugLabel": "",
@@ -815,6 +820,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({data1}){\n    const result = data1.split(\"```\").filter(item => !!item.trim())\n\n    if(result[result.length-1]) {\n        return {\n            result: result[result.length-1]\n        }\n    }\n\n    return {\n        result: '未截取到翻译内容'\n    }\n}",
             "debugLabel": "",
@@ -1001,6 +1007,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "debugLabel": "",
@@ -1009,6 +1016,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({source_lang, target_lang}){\n    \n    return {\n        result: source_lang === target_lang\n    }\n}",
             "debugLabel": "",
@@ -1206,6 +1214,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "valueDesc": "",
@@ -1216,6 +1225,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "const MAX_HEADING_LENGTH = 7; // 最大标题长度\nconst MAX_HEADING_CONTENT_LENGTH = 200; // 最大标题内容长度\nconst MAX_HEADING_UNDERLINE_LENGTH = 200; // 最大标题下划线长度\nconst MAX_HTML_HEADING_ATTRIBUTES_LENGTH = 100; // 最大HTML标题属性长度\nconst MAX_LIST_ITEM_LENGTH = 200; // 最大列表项长度\nconst MAX_NESTED_LIST_ITEMS = 6; // 最大嵌套列表项数\nconst MAX_LIST_INDENT_SPACES = 7; // 最大列表缩进空格数\nconst MAX_BLOCKQUOTE_LINE_LENGTH = 200; // 最大块引用行长度\nconst MAX_BLOCKQUOTE_LINES = 15; // 最大块引用行数\nconst MAX_CODE_BLOCK_LENGTH = 1500; // 最大代码块长度\nconst MAX_CODE_LANGUAGE_LENGTH = 20; // 最大代码语言长度\nconst MAX_INDENTED_CODE_LINES = 20; // 最大缩进代码行数\nconst MAX_TABLE_CELL_LENGTH = 200; // 最大表格单元格长度\nconst MAX_TABLE_ROWS = 20; // 最大表格行数\nconst MAX_HTML_TABLE_LENGTH = 2000; // 最大HTML表格长度\nconst MIN_HORIZONTAL_RULE_LENGTH = 3; // 最小水平分隔线长度\nconst MAX_SENTENCE_LENGTH = 400; // 最大句子长度\nconst MAX_QUOTED_TEXT_LENGTH = 300; // 最大引用文本长度\nconst MAX_PARENTHETICAL_CONTENT_LENGTH = 200; // 最大括号内容长度\nconst MAX_NESTED_PARENTHESES = 5; // 最大嵌套括号数\nconst MAX_MATH_INLINE_LENGTH = 100; // 最大行内数学公式长度\nconst MAX_MATH_BLOCK_LENGTH = 500; // 最大数学公式块长度\nconst MAX_PARAGRAPH_LENGTH = 1000; // 最大段落长度\nconst MAX_STANDALONE_LINE_LENGTH = 800; // 最大独立行长度\nconst MAX_HTML_TAG_ATTRIBUTES_LENGTH = 100; // 最大HTML标签属性长度\nconst MAX_HTML_TAG_CONTENT_LENGTH = 1000; // 最大HTML标签内容长度\nconst LOOKAHEAD_RANGE = 100;  // 向前查找句子边界的字符数\n\nconst AVOID_AT_START = `[\\\\s\\\\]})>,']`; // 避免在开头匹配的字符\nconst PUNCTUATION = `[.!?…]|\\\\.{3}|[\\\\u2026\\\\u2047-\\\\u2049]|[\\\\p{Emoji_Presentation}\\\\p{Extended_Pictographic}]`; // 标点符号\nconst QUOTE_END = `(?:'(?=\\`)|''(?=\\`\\`))`; // 引号结束\nconst SENTENCE_END = `(?:${PUNCTUATION}(?<!${AVOID_AT_START}(?=${PUNCTUATION}))|${QUOTE_END})(?=\\\\S|$)`; // 句子结束\nconst SENTENCE_BOUNDARY = `(?:${SENTENCE_END}|(?=[\\\\r\\\\n]|$))`; // 句子边界\nconst LOOKAHEAD_PATTERN = `(?:(?!${SENTENCE_END}).){1,${LOOKAHEAD_RANGE}}${SENTENCE_END}`; // 向前查找句子结束的模式\nconst NOT_PUNCTUATION_SPACE = `(?!${PUNCTUATION}\\\\s)`; // 非标点符号空格\nconst SENTENCE_PATTERN = `${NOT_PUNCTUATION_SPACE}(?:[^\\\\r\\\\n]{1,{MAX_LENGTH}}${SENTENCE_BOUNDARY}|[^\\\\r\\\\n]{1,{MAX_LENGTH}}(?=${PUNCTUATION}|${QUOTE_END})(?:${LOOKAHEAD_PATTERN})?)${AVOID_AT_START}*`; // 句子模式\n\nconst regex = new RegExp(\n  \"(\" +\n  // 1. Headings (Setext-style, Markdown, and HTML-style, with length constraints)\n  `(?:^(?:[#*=-]{1,${MAX_HEADING_LENGTH}}|\\\\w[^\\\\r\\\\n]{0,${MAX_HEADING_CONTENT_LENGTH}}\\\\r?\\\\n[-=]{2,${MAX_HEADING_UNDERLINE_LENGTH}}|<h[1-6][^>]{0,${MAX_HTML_HEADING_ATTRIBUTES_LENGTH}}>)[^\\\\r\\\\n]{1,${MAX_HEADING_CONTENT_LENGTH}}(?:</h[1-6]>)?(?:\\\\r?\\\\n|$))` +\n  \"|\" +\n  // New pattern for citations\n  `(?:\\\\[[0-9]+\\\\][^\\\\r\\\\n]{1,${MAX_STANDALONE_LINE_LENGTH}})` +\n  \"|\" +\n  // 2. List items (bulleted, numbered, lettered, or task lists, including nested, up to three levels, with length constraints)\n  `(?:(?:^|\\\\r?\\\\n)[ \\\\t]{0,3}(?:[-*+•]|\\\\d{1,3}\\\\.\\\\w\\\\.|\\\\[[ xX]\\\\])[ \\\\t]+${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_LIST_ITEM_LENGTH))}` +\n  `(?:(?:\\\\r?\\\\n[ \\\\t]{2,5}(?:[-*+•]|\\\\d{1,3}\\\\.\\\\w\\\\.|\\\\[[ xX]\\\\])[ \\\\t]+${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_LIST_ITEM_LENGTH))}){0,${MAX_NESTED_LIST_ITEMS}}` +\n  `(?:\\\\r?\\\\n[ \\\\t]{4,${MAX_LIST_INDENT_SPACES}}(?:[-*+•]|\\\\d{1,3}\\\\.\\\\w\\\\.|\\\\[[ xX]\\\\])[ \\\\t]+${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_LIST_ITEM_LENGTH))}){0,${MAX_NESTED_LIST_ITEMS}})?)` +\n  \"|\" +\n  // 3. Block quotes (including nested quotes and citations, up to three levels, with length constraints)\n  `(?:(?:^>(?:>|\\\\s{2,}){0,2}${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_BLOCKQUOTE_LINE_LENGTH))}\\\\r?\\\\n?){1,${MAX_BLOCKQUOTE_LINES}})` +\n  \"|\" +\n  // 4. Code blocks (fenced, indented, or HTML pre/code tags, with length constraints)\n  `(?:(?:^|\\\\r?\\\\n)(?:\\`\\`\\`|~~~)(?:\\\\w{0,${MAX_CODE_LANGUAGE_LENGTH}})?\\\\r?\\\\n[\\\\s\\\\S]{0,${MAX_CODE_BLOCK_LENGTH}}?(?:\\`\\`\\`|~~~)\\\\r?\\\\n?` +\n  `|(?:(?:^|\\\\r?\\\\n)(?: {4}|\\\\t)[^\\\\r\\\\n]{0,${MAX_LIST_ITEM_LENGTH}}(?:\\\\r?\\\\n(?: {4}|\\\\t)[^\\\\r\\\\n]{0,${MAX_LIST_ITEM_LENGTH}}){0,${MAX_INDENTED_CODE_LINES}}\\\\r?\\\\n?)` +\n  `|(?:<pre>(?:<code>)?[\\\\s\\\\S]{0,${MAX_CODE_BLOCK_LENGTH}}?(?:</code>)?</pre>))` +\n  \"|\" +\n  // 5. Tables (Markdown, grid tables, and HTML tables, with length constraints)\n  `(?:(?:^|\\\\r?\\\\n)(?:\\\\|[^\\\\r\\\\n]{0,${MAX_TABLE_CELL_LENGTH}}\\\\|(?:\\\\r?\\\\n\\\\|[-:]{1,${MAX_TABLE_CELL_LENGTH}}\\\\|){0,1}(?:\\\\r?\\\\n\\\\|[^\\\\r\\\\n]{0,${MAX_TABLE_CELL_LENGTH}}\\\\|){0,${MAX_TABLE_ROWS}}` +\n  `|<table>[\\\\s\\\\S]{0,${MAX_HTML_TABLE_LENGTH}}?</table>))` +\n  \"|\" +\n  // 6. Horizontal rules (Markdown and HTML hr tag)\n  `(?:^(?:[-*_]){${MIN_HORIZONTAL_RULE_LENGTH},}\\\\s*$|<hr\\\\s*/?>)` +\n  \"|\" +\n  // 10. Standalone lines or phrases (including single-line blocks and HTML elements, with length constraints)\n  `(?!${AVOID_AT_START})(?:^(?:<[a-zA-Z][^>]{0,${MAX_HTML_TAG_ATTRIBUTES_LENGTH}}>)?${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_STANDALONE_LINE_LENGTH))}(?:</[a-zA-Z]+>)?(?:\\\\r?\\\\n|$))` +\n  \"|\" +\n  // 7. Sentences or phrases ending with punctuation (including ellipsis and Unicode punctuation)\n  `(?!${AVOID_AT_START})${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_SENTENCE_LENGTH))}` +\n  \"|\" +\n  // 8. Quoted text, parenthetical phrases, or bracketed content (with length constraints)\n  \"(?:\" +\n  `(?<!\\\\w)\\\"\\\"\\\"[^\\\"]{0,${MAX_QUOTED_TEXT_LENGTH}}\\\"\\\"\\\"(?!\\\\w)` +\n  `|(?<!\\\\w)(?:['\\\"\\`'\"])[^\\\\r\\\\n]{0,${MAX_QUOTED_TEXT_LENGTH}}\\\\1(?!\\\\w)` +\n  `|(?<!\\\\w)\\`[^\\\\r\\\\n]{0,${MAX_QUOTED_TEXT_LENGTH}}'(?!\\\\w)` +\n  `|(?<!\\\\w)\\`\\`[^\\\\r\\\\n]{0,${MAX_QUOTED_TEXT_LENGTH}}''(?!\\\\w)` +\n  `|\\\\([^\\\\r\\\\n()]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}(?:\\\\([^\\\\r\\\\n()]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}\\\\)[^\\\\r\\\\n()]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}){0,${MAX_NESTED_PARENTHESES}}\\\\)` +\n  `|\\\\[[^\\\\r\\\\n\\\\[\\\\]]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}(?:\\\\[[^\\\\r\\\\n\\\\[\\\\]]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}\\\\][^\\\\r\\\\n\\\\[\\\\]]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}){0,${MAX_NESTED_PARENTHESES}}\\\\]` +\n  `|\\\\$[^\\\\r\\\\n$]{0,${MAX_MATH_INLINE_LENGTH}}\\\\$` +\n  `|\\`[^\\`\\\\r\\\\n]{0,${MAX_MATH_INLINE_LENGTH}}\\`` +\n  \")\" +\n  \"|\" +\n  // 9. Paragraphs (with length constraints)\n  `(?!${AVOID_AT_START})(?:(?:^|\\\\r?\\\\n\\\\r?\\\\n)(?:<p>)?${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_PARAGRAPH_LENGTH))}(?:</p>)?(?=\\\\r?\\\\n\\\\r?\\\\n|$))` +\n  \"|\" +\n  // 11. HTML-like tags and their content (including self-closing tags and attributes, with length constraints)\n  `(?:<[a-zA-Z][^>]{0,${MAX_HTML_TAG_ATTRIBUTES_LENGTH}}(?:>[\\\\s\\\\S]{0,${MAX_HTML_TAG_CONTENT_LENGTH}}?</[a-zA-Z]+>|\\\\s*/>))` +\n  \"|\" +\n  // 12. LaTeX-style math expressions (inline and block, with length constraints)\n  `(?:(?:\\\\$\\\\$[\\\\s\\\\S]{0,${MAX_MATH_BLOCK_LENGTH}}?\\\\$\\\\$)|(?:\\\\$[^\\\\$\\\\r\\\\n]{0,${MAX_MATH_INLINE_LENGTH}}\\\\$))` +\n  \"|\" +\n  // 14. Fallback for any remaining content (with length constraints)\n  `(?!${AVOID_AT_START})${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_STANDALONE_LINE_LENGTH))}` +\n  \")\",\n  \"gmu\"\n);\n\nfunction main({text}){\n  const chunks = [];\n  let currentChunk = '';\n  const tokens = countToken(text)\n\n  const matches = text.match(regex);\n  if (matches) {\n    matches.forEach((match) => {\n      if (currentChunk.length + match.length <= 1000) {\n        currentChunk += match;\n      } else {\n        if (currentChunk) {\n          chunks.push(currentChunk);\n        }\n        currentChunk = match;\n      }\n    });\n    if (currentChunk) {\n      chunks.push(currentChunk);\n    }\n  }\n\n  return {chunks, tokens};\n}\n\n",
             "valueDesc": "",
@@ -1600,6 +1610,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "valueDesc": "",
@@ -1610,6 +1621,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "const MAX_HEADING_LENGTH = 7; // 最大标题长度\nconst MAX_HEADING_CONTENT_LENGTH = 200; // 最大标题内容长度\nconst MAX_HEADING_UNDERLINE_LENGTH = 200; // 最大标题下划线长度\nconst MAX_HTML_HEADING_ATTRIBUTES_LENGTH = 100; // 最大HTML标题属性长度\nconst MAX_LIST_ITEM_LENGTH = 200; // 最大列表项长度\nconst MAX_NESTED_LIST_ITEMS = 6; // 最大嵌套列表项数\nconst MAX_LIST_INDENT_SPACES = 7; // 最大列表缩进空格数\nconst MAX_BLOCKQUOTE_LINE_LENGTH = 200; // 最大块引用行长度\nconst MAX_BLOCKQUOTE_LINES = 15; // 最大块引用行数\nconst MAX_CODE_BLOCK_LENGTH = 1500; // 最大代码块长度\nconst MAX_CODE_LANGUAGE_LENGTH = 20; // 最大代码语言长度\nconst MAX_INDENTED_CODE_LINES = 20; // 最大缩进代码行数\nconst MAX_TABLE_CELL_LENGTH = 200; // 最大表格单元格长度\nconst MAX_TABLE_ROWS = 20; // 最大表格行数\nconst MAX_HTML_TABLE_LENGTH = 2000; // 最大HTML表格长度\nconst MIN_HORIZONTAL_RULE_LENGTH = 3; // 最小水平分隔线长度\nconst MAX_SENTENCE_LENGTH = 400; // 最大句子长度\nconst MAX_QUOTED_TEXT_LENGTH = 300; // 最大引用文本长度\nconst MAX_PARENTHETICAL_CONTENT_LENGTH = 200; // 最大括号内容长度\nconst MAX_NESTED_PARENTHESES = 5; // 最大嵌套括号数\nconst MAX_MATH_INLINE_LENGTH = 100; // 最大行内数学公式长度\nconst MAX_MATH_BLOCK_LENGTH = 500; // 最大数学公式块长度\nconst MAX_PARAGRAPH_LENGTH = 1000; // 最大段落长度\nconst MAX_STANDALONE_LINE_LENGTH = 800; // 最大独立行长度\nconst MAX_HTML_TAG_ATTRIBUTES_LENGTH = 100; // 最大HTML标签属性长度\nconst MAX_HTML_TAG_CONTENT_LENGTH = 1000; // 最大HTML标签内容长度\nconst LOOKAHEAD_RANGE = 100;  // 向前查找句子边界的字符数\n\nconst AVOID_AT_START = `[\\\\s\\\\]})>,']`; // 避免在开头匹配的字符\nconst PUNCTUATION = `[.!?…]|\\\\.{3}|[\\\\u2026\\\\u2047-\\\\u2049]|[\\\\p{Emoji_Presentation}\\\\p{Extended_Pictographic}]`; // 标点符号\nconst QUOTE_END = `(?:'(?=\\`)|''(?=\\`\\`))`; // 引号结束\nconst SENTENCE_END = `(?:${PUNCTUATION}(?<!${AVOID_AT_START}(?=${PUNCTUATION}))|${QUOTE_END})(?=\\\\S|$)`; // 句子结束\nconst SENTENCE_BOUNDARY = `(?:${SENTENCE_END}|(?=[\\\\r\\\\n]|$))`; // 句子边界\nconst LOOKAHEAD_PATTERN = `(?:(?!${SENTENCE_END}).){1,${LOOKAHEAD_RANGE}}${SENTENCE_END}`; // 向前查找句子结束的模式\nconst NOT_PUNCTUATION_SPACE = `(?!${PUNCTUATION}\\\\s)`; // 非标点符号空格\nconst SENTENCE_PATTERN = `${NOT_PUNCTUATION_SPACE}(?:[^\\\\r\\\\n]{1,{MAX_LENGTH}}${SENTENCE_BOUNDARY}|[^\\\\r\\\\n]{1,{MAX_LENGTH}}(?=${PUNCTUATION}|${QUOTE_END})(?:${LOOKAHEAD_PATTERN})?)${AVOID_AT_START}*`; // 句子模式\n\nconst regex = new RegExp(\n  \"(\" +\n  // 1. Headings (Setext-style, Markdown, and HTML-style, with length constraints)\n  `(?:^(?:[#*=-]{1,${MAX_HEADING_LENGTH}}|\\\\w[^\\\\r\\\\n]{0,${MAX_HEADING_CONTENT_LENGTH}}\\\\r?\\\\n[-=]{2,${MAX_HEADING_UNDERLINE_LENGTH}}|<h[1-6][^>]{0,${MAX_HTML_HEADING_ATTRIBUTES_LENGTH}}>)[^\\\\r\\\\n]{1,${MAX_HEADING_CONTENT_LENGTH}}(?:</h[1-6]>)?(?:\\\\r?\\\\n|$))` +\n  \"|\" +\n  // New pattern for citations\n  `(?:\\\\[[0-9]+\\\\][^\\\\r\\\\n]{1,${MAX_STANDALONE_LINE_LENGTH}})` +\n  \"|\" +\n  // 2. List items (bulleted, numbered, lettered, or task lists, including nested, up to three levels, with length constraints)\n  `(?:(?:^|\\\\r?\\\\n)[ \\\\t]{0,3}(?:[-*+•]|\\\\d{1,3}\\\\.\\\\w\\\\.|\\\\[[ xX]\\\\])[ \\\\t]+${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_LIST_ITEM_LENGTH))}` +\n  `(?:(?:\\\\r?\\\\n[ \\\\t]{2,5}(?:[-*+•]|\\\\d{1,3}\\\\.\\\\w\\\\.|\\\\[[ xX]\\\\])[ \\\\t]+${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_LIST_ITEM_LENGTH))}){0,${MAX_NESTED_LIST_ITEMS}}` +\n  `(?:\\\\r?\\\\n[ \\\\t]{4,${MAX_LIST_INDENT_SPACES}}(?:[-*+•]|\\\\d{1,3}\\\\.\\\\w\\\\.|\\\\[[ xX]\\\\])[ \\\\t]+${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_LIST_ITEM_LENGTH))}){0,${MAX_NESTED_LIST_ITEMS}})?)` +\n  \"|\" +\n  // 3. Block quotes (including nested quotes and citations, up to three levels, with length constraints)\n  `(?:(?:^>(?:>|\\\\s{2,}){0,2}${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_BLOCKQUOTE_LINE_LENGTH))}\\\\r?\\\\n?){1,${MAX_BLOCKQUOTE_LINES}})` +\n  \"|\" +\n  // 4. Code blocks (fenced, indented, or HTML pre/code tags, with length constraints)\n  `(?:(?:^|\\\\r?\\\\n)(?:\\`\\`\\`|~~~)(?:\\\\w{0,${MAX_CODE_LANGUAGE_LENGTH}})?\\\\r?\\\\n[\\\\s\\\\S]{0,${MAX_CODE_BLOCK_LENGTH}}?(?:\\`\\`\\`|~~~)\\\\r?\\\\n?` +\n  `|(?:(?:^|\\\\r?\\\\n)(?: {4}|\\\\t)[^\\\\r\\\\n]{0,${MAX_LIST_ITEM_LENGTH}}(?:\\\\r?\\\\n(?: {4}|\\\\t)[^\\\\r\\\\n]{0,${MAX_LIST_ITEM_LENGTH}}){0,${MAX_INDENTED_CODE_LINES}}\\\\r?\\\\n?)` +\n  `|(?:<pre>(?:<code>)?[\\\\s\\\\S]{0,${MAX_CODE_BLOCK_LENGTH}}?(?:</code>)?</pre>))` +\n  \"|\" +\n  // 5. Tables (Markdown, grid tables, and HTML tables, with length constraints)\n  `(?:(?:^|\\\\r?\\\\n)(?:\\\\|[^\\\\r\\\\n]{0,${MAX_TABLE_CELL_LENGTH}}\\\\|(?:\\\\r?\\\\n\\\\|[-:]{1,${MAX_TABLE_CELL_LENGTH}}\\\\|){0,1}(?:\\\\r?\\\\n\\\\|[^\\\\r\\\\n]{0,${MAX_TABLE_CELL_LENGTH}}\\\\|){0,${MAX_TABLE_ROWS}}` +\n  `|<table>[\\\\s\\\\S]{0,${MAX_HTML_TABLE_LENGTH}}?</table>))` +\n  \"|\" +\n  // 6. Horizontal rules (Markdown and HTML hr tag)\n  `(?:^(?:[-*_]){${MIN_HORIZONTAL_RULE_LENGTH},}\\\\s*$|<hr\\\\s*/?>)` +\n  \"|\" +\n  // 10. Standalone lines or phrases (including single-line blocks and HTML elements, with length constraints)\n  `(?!${AVOID_AT_START})(?:^(?:<[a-zA-Z][^>]{0,${MAX_HTML_TAG_ATTRIBUTES_LENGTH}}>)?${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_STANDALONE_LINE_LENGTH))}(?:</[a-zA-Z]+>)?(?:\\\\r?\\\\n|$))` +\n  \"|\" +\n  // 7. Sentences or phrases ending with punctuation (including ellipsis and Unicode punctuation)\n  `(?!${AVOID_AT_START})${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_SENTENCE_LENGTH))}` +\n  \"|\" +\n  // 8. Quoted text, parenthetical phrases, or bracketed content (with length constraints)\n  \"(?:\" +\n  `(?<!\\\\w)\\\"\\\"\\\"[^\\\"]{0,${MAX_QUOTED_TEXT_LENGTH}}\\\"\\\"\\\"(?!\\\\w)` +\n  `|(?<!\\\\w)(?:['\\\"\\`'\"])[^\\\\r\\\\n]{0,${MAX_QUOTED_TEXT_LENGTH}}\\\\1(?!\\\\w)` +\n  `|(?<!\\\\w)\\`[^\\\\r\\\\n]{0,${MAX_QUOTED_TEXT_LENGTH}}'(?!\\\\w)` +\n  `|(?<!\\\\w)\\`\\`[^\\\\r\\\\n]{0,${MAX_QUOTED_TEXT_LENGTH}}''(?!\\\\w)` +\n  `|\\\\([^\\\\r\\\\n()]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}(?:\\\\([^\\\\r\\\\n()]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}\\\\)[^\\\\r\\\\n()]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}){0,${MAX_NESTED_PARENTHESES}}\\\\)` +\n  `|\\\\[[^\\\\r\\\\n\\\\[\\\\]]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}(?:\\\\[[^\\\\r\\\\n\\\\[\\\\]]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}\\\\][^\\\\r\\\\n\\\\[\\\\]]{0,${MAX_PARENTHETICAL_CONTENT_LENGTH}}){0,${MAX_NESTED_PARENTHESES}}\\\\]` +\n  `|\\\\$[^\\\\r\\\\n$]{0,${MAX_MATH_INLINE_LENGTH}}\\\\$` +\n  `|\\`[^\\`\\\\r\\\\n]{0,${MAX_MATH_INLINE_LENGTH}}\\`` +\n  \")\" +\n  \"|\" +\n  // 9. Paragraphs (with length constraints)\n  `(?!${AVOID_AT_START})(?:(?:^|\\\\r?\\\\n\\\\r?\\\\n)(?:<p>)?${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_PARAGRAPH_LENGTH))}(?:</p>)?(?=\\\\r?\\\\n\\\\r?\\\\n|$))` +\n  \"|\" +\n  // 11. HTML-like tags and their content (including self-closing tags and attributes, with length constraints)\n  `(?:<[a-zA-Z][^>]{0,${MAX_HTML_TAG_ATTRIBUTES_LENGTH}}(?:>[\\\\s\\\\S]{0,${MAX_HTML_TAG_CONTENT_LENGTH}}?</[a-zA-Z]+>|\\\\s*/>))` +\n  \"|\" +\n  // 12. LaTeX-style math expressions (inline and block, with length constraints)\n  `(?:(?:\\\\$\\\\$[\\\\s\\\\S]{0,${MAX_MATH_BLOCK_LENGTH}}?\\\\$\\\\$)|(?:\\\\$[^\\\\$\\\\r\\\\n]{0,${MAX_MATH_INLINE_LENGTH}}\\\\$))` +\n  \"|\" +\n  // 14. Fallback for any remaining content (with length constraints)\n  `(?!${AVOID_AT_START})${SENTENCE_PATTERN.replace(/{MAX_LENGTH}/g, String(MAX_STANDALONE_LINE_LENGTH))}` +\n  \")\",\n  \"gmu\"\n);\n\nfunction main({text}){\n  const chunks = [];\n  let currentChunk = '';\n  const tokens = countToken(text)\n\n  const matches = text.match(regex);\n  if (matches) {\n    matches.forEach((match) => {\n      if (currentChunk.length + match.length <= 1000) {\n        currentChunk += match;\n      } else {\n        if (currentChunk) {\n          chunks.push(currentChunk);\n        }\n        currentChunk = match;\n      }\n    });\n    if (currentChunk) {\n      chunks.push(currentChunk);\n    }\n  }\n\n  return {chunks, tokens};\n}\n\n",
             "valueDesc": "",
@@ -1790,6 +1802,7 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js",
             "valueDesc": "",
@@ -1800,6 +1813,7 @@
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({target_lang, source_text}) {\n  let text = source_text;\n\n  if (target_lang === '简体中文' || target_lang === '繁體中文') {\n    // 存储代码块内容\n    const codeBlocks = [];\n    let text = source_text.replace(/```[\\s\\S]*?```/g, (match) => {\n      codeBlocks.push(match);\n      return `__CODE_BLOCK_${codeBlocks.length - 1}__`;\n    });\n\n    // 替换成对的英文引号\n    text = text.replace(/\"(.*?)\"/g, '“$1”');\n\n    // 保护 Markdown 链接格式中的括号\n    text = text.replace(/\\[(.*?)\\]\\((.*?)\\)/g, function(match) {\n      return match.replace(/\\(/g, 'LEFTPAREN')\n                 .replace(/\\)/g, 'RIGHTPAREN');\n    });\n\n    // 替换成对的英文括号\n    text = text.replace(/\\((.*?)\\)/g, '（$1）');\n\n    // 恢复被保护的 Markdown 链接括号\n    text = text.replace(/LEFTPAREN/g, '(')\n             .replace(/RIGHTPAREN/g, ')');\n\n    // 更新句号替换逻辑，增加对版本号和URL的保护\n    text = text.replace(/(\\d+)\\.(\\d+)\\.(\\d+)/g, '$1DOT$2DOT$3') // 保护版本号 (如 16.2.1)\n               .replace(/(\\d)\\.(\\d)/g, '$1DOT$2') // 临时替换小数点\n               .replace(/([a-zA-Z])\\.([a-zA-Z])/g, '$1DOT$2') // 临时替换缩写中的句号\n               .replace(/([a-zA-Z])\\.(\\d)/g, '$1DOT$2') // 临时替换字母与数字之间的句号\n               .replace(/(\\d)\\.([a-zA-Z])/g, '$1DOT$2') // 临时替换数字与字母之间的句号\n               .replace(/([a-zA-Z])\\./g, '$1DOT') // 临时替换字母后面的句号（如 a.）\n               .replace(/https?:/g, 'HTTPCOLON') // 保护 URL 中的冒号\n               .replace(/\\./g, '。') // 替换其他句号\n               .replace(/DOT/g, '.') // 恢复被保护的句号\n               .replace(/HTTPCOLON/g, 'http:'); // 恢复 URL 中的冒号\n\n    // 替换英文逗号，但不替换数字中的逗号\n    text = text.replace(/(\\d),(\\d)/g, '$1COMMA$2') // 临时替换数字中的逗号\n               .replace(/,/g, '，') // 替换其他逗号\n               .replace(/COMMA/g, ','); // 恢复数字中的逗号\n\n    // 替换其他常见符号\n    const replacements = {\n      '!': '！',\n      '?': '？',\n      ';': '；',\n    };\n\n    for (const [key, value] of Object.entries(replacements)) {\n      text = text.replace(new RegExp(`\\\\${key}`, 'g'), value);\n    }\n\n    // 在中文和英文字符之间添加空格\n    // 中文字符范围: \\u4e00-\\u9fa5\n    // 英文字符范围: a-zA-Z0-9\n    text = text.replace(/([\\u4e00-\\u9fa5])([a-zA-Z0-9])/g, '$1 $2')\n               .replace(/([a-zA-Z0-9])([\\u4e00-\\u9fa5])/g, '$1 $2');\n\n    // 恢复代码块\n    text = text.replace(/__CODE_BLOCK_(\\d+)__/g, (_, index) => codeBlocks[index]);\n  }\n\n  return {\n    text\n  };\n}",
             "valueDesc": "",

--- a/modules/workflow/templates/srt-translate.json
+++ b/modules/workflow/templates/srt-translate.json
@@ -39,7 +39,7 @@
           },
           {
             "key": "questionGuide",
-            "valueType": "any",
+            "valueType": "object",
             "renderTypeList": ["hidden"],
             "label": "core.app.Question Guide",
             "value": {
@@ -446,12 +446,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({chunks, currentChunk}){\n    const findIndex = chunks.findIndex((item) => item === currentChunk)\n\n    return {\n        isEnd: chunks.length-1 === findIndex,\n        i: findIndex + 1,\n    }\n}"
           },
@@ -618,12 +620,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({source_text_chunks, i=0}){\n    let before = source_text_chunks.slice(0, i).join(\"\");\n    let current = \" <TRANSLATE_THIS>\" + source_text_chunks[i] + \"</TRANSLATE_THIS>\";\n    let after = source_text_chunks.slice(i + 1).join(\"\");\n    let tagged_text = before + current + after;\n\n    return {\n        tagged_text,\n        chunk_to_translate: source_text_chunks[i],\n    }\n}"
           },
@@ -819,12 +823,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({data1}){\n    const result = data1.split(\"```\").filter(item => !!item.trim())\n\n    if(result[result.length-1]) {\n        return {\n            result: result[result.length-1].trim() \n        }\n    }\n\n    return {\n        result: '未截取到翻译内容'\n    }\n}"
           },
@@ -1008,12 +1014,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({source_lang, target_lang}){\n    \n    return {\n        result: source_lang === target_lang\n    }\n}"
           },
@@ -1225,12 +1233,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({text}){\n  const lines = text.split('\\n');\n  const timePattern = /\\d{2}:\\d{2}:\\d{2},\\d{3} --> \\d{2}:\\d{2}:\\d{2},\\d{3}/;\n  const numberInfo = [];\n  const timeInfo = [];\n  const textInfo = [];\n  let currentText = [];\n\n  // 提取序号、时间戳和文本信息\n  lines.forEach(line => {\n    if (/^\\d+$/.test(line.trim())) {\n      numberInfo.push(line.trim());\n    } else if (timePattern.test(line)) {\n      timeInfo.push(line);\n      if (currentText.length > 0) {\n        textInfo.push(currentText.join(' '));\n        currentText = [];\n      }\n    } else if (line.trim() === '') {\n      // Skip empty lines\n    } else {\n      currentText.push(line.trim());\n    }\n  });\n\n  if (currentText.length > 0) {\n    textInfo.push(currentText.join(' '));\n  }\n\n  return { numberInfo, timeInfo, textInfo };\n}"
           },
@@ -1375,12 +1385,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({combinedText, transedText, timeInfo, currentIndex=0,numberInfo}){\n  const textLines = combinedText.split('<T>');\n  const resultLines = transedText.split('<T>');\n  const combinedLines = [];\n\n  resultLines.forEach((line, index) => {\n    combinedLines.push(numberInfo[currentIndex+index]);\n    combinedLines.push(timeInfo[currentIndex+index]);\n    combinedLines.push(line)\n    combinedLines.push(textLines[index]);\n    combinedLines.push('');\n  });\n\n  const srtContent = combinedLines.join('\\n');\n  \n\n    return {\n        srtContent,\n        currentIndex: currentIndex+textLines.length\n    }\n}"
           },
@@ -1634,12 +1646,14 @@
           {
             "key": "codeType",
             "renderTypeList": ["hidden"],
+            "valueType": "string",
             "label": "",
             "value": "js"
           },
           {
             "key": "code",
             "renderTypeList": ["custom"],
+            "valueType": "string",
             "label": "",
             "value": "function main({textArray}){\n const groupSize = 40\n const delimiter = '<T>'\n\n  const result = [];\n\n  for (let i = 0; i < textArray.length; i += groupSize) {\n    result.push(textArray.slice(i, i + groupSize).join(delimiter));\n  }\n\n  return {result};\n}"
           },


### PR DESCRIPTION
## Summary
- Add the official Alibaba Cloud Model Studio `qwen3.7-max` model preset to the Qwen provider.
- Keep existing Qwen model parameters unchanged and skip dated/preview Qwen3.7 aliases per the automation scope.

## Source
- https://help.aliyun.com/zh/model-studio/text-generation-model/

## Validation
- PASS: git diff --check
- PASS: bunx prettier --check modules/model/provider/Qwen/index.ts
- PASS: Qwen provider schema parse via Bun (38 models)

Note: this PR uses the shared `dev` branch per the updated automation workflow, so it also carries the existing `fix: template` commit already on `dev`.