### PR TITLE
feat(model): refresh Mistral provider presets

### DIFF
--- a/modules/model/provider/MistralAI/index.ts
+++ b/modules/model/provider/MistralAI/index.ts
@@ -29,24 +29,24 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'mistral-medium-3-5',
+      maxContext: 256000,
+      maxTokens: 32000,
+      quoteMaxToken: 240000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'mistral-medium-2508',
       maxContext: 128000,
       maxTokens: 8000,
       quoteMaxToken: 120000,
       maxTemperature: 1.2,
       vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'devstral-2512',
-      maxContext: 131000,
-      maxTokens: 8000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1.2,
-      vision: false,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true


### PR DESCRIPTION
## Summary
- Add the current Mistral Medium 3.5 public model preset: mistral-medium-3-5.
- Remove the deprecated Devstral 2 preset: devstral-2512.
- Keep mistral-medium-2508 because it is still documented separately by Mistral.

## Official sources checked
- https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04
- https://docs.mistral.ai/studio-api/conversations/reasoning
- https://docs.mistral.ai/models/model-cards/devstral-2-25-12

## Validation
- bun tsc --noEmit
- git diff --check
- node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider MistralAI

## Notes
bun run test was run and failed in pre-existing unrelated areas: external Feishu/Tavily integration calls, Vitest path alias resolution, and existing bun:test imports under docDiff tests. No failures pointed at the Mistral provider preset change.
