### PR TITLE
feat(model): refresh Jina provider presets

### DIFF
--- a/modules/model/provider/Jina/index.ts
+++ b/modules/model/provider/Jina/index.ts
@@ -5,9 +5,50 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.embedding,
+      model: 'jina-embeddings-v5-omni-small',
+      defaultToken: 512,
+      maxToken: 32000
+    },
+    {
+      type: ModelTypeEnum.embedding,
+      model: 'jina-embeddings-v5-text-small',
+      defaultToken: 512,
+      maxToken: 32000
+    },
+    {
+      type: ModelTypeEnum.embedding,
+      model: 'jina-embeddings-v5-omni-nano',
+      defaultToken: 512,
+      maxToken: 8000
+    },
+    {
+      type: ModelTypeEnum.embedding,
+      model: 'jina-embeddings-v5-text-nano',
+      defaultToken: 512,
+      maxToken: 8000
+    },
+    {
+      type: ModelTypeEnum.embedding,
+      model: 'jina-embeddings-v4',
+      defaultToken: 512,
+      maxToken: 32000
+    },
+    {
+      type: ModelTypeEnum.embedding,
+      model: 'jina-clip-v2',
+      defaultToken: 512,
+      maxToken: 8000
+    },
+    {
+      type: ModelTypeEnum.embedding,
       model: 'jina-embeddings-v3',
       defaultToken: 512,
       maxToken: 8000
+    },
+    {
+      type: ModelTypeEnum.rerank,
+      model: 'jina-reranker-v3',
+      maxToken: 134144
     },
     {
       type: ModelTypeEnum.rerank,


### PR DESCRIPTION
## Summary
- add latest Jina v5 text embedding presets (`jina-embeddings-v5-text-small`, `jina-embeddings-v5-text-nano`)
- add multimodal Jina embedding presets (`jina-embeddings-v5-omni-small`, `jina-embeddings-v5-omni-nano`, `jina-embeddings-v4`, `jina-clip-v2`)
- add latest Jina reranker preset (`jina-reranker-v3`) while keeping existing Jina presets

## Sources
- https://docs.jina.ai/embeddings/
- https://api.jina.ai/v1/models
- https://jina.ai/embeddings/

## Validation
- `node /tmp/model_provider_presets.mjs inventory --repo-root /Volumes/code/dev/fastgpt-plugin --provider Jina --json`
- `bun -e "import { ProviderConfigSchema } from './modules/model/type'; import Jina from './modules/model/provider/Jina'; ProviderConfigSchema.parse(Jina); console.log(JSON.stringify({ provider: Jina.provider, count: Jina.list.length }));"`
- `git diff --check`
- `bun tsc --noEmit`

## Test note
- `bun run test` was run and fails on existing unrelated suite issues: Vitest cannot resolve `bun:test` in several docDiff tests, `@/...` path aliases are unresolved in multiple tool tests, and Feishu/Tavily integration tests hit external/API assertions.
