### PR TITLE
feat(model): add Qwen3.7 Plus preset

### DIFF
--- a/modules/model/provider/Qwen/index.ts
+++ b/modules/model/provider/Qwen/index.ts
@@ -23,6 +23,19 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'qwen3.7-plus',
+      maxContext: 1000000,
+      maxTokens: 64000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'qwen3.6-max-preview',
       maxContext: 260000,
       maxTokens: 64000,


### PR DESCRIPTION
## Summary
- add the Qwen `qwen3.7-plus` LLM preset
- set 1M context, 64k max output, multimodal/vision support, reasoning, tool calling, and structured output fields from official Alibaba Cloud Model Studio docs

## Evidence
- https://help.aliyun.com/zh/model-studio/text-generation-model/
- https://help.aliyun.com/zh/model-studio/vision-model/
- https://help.aliyun.com/zh/model-studio/deep-thinking

## Validation
- `bun tsc --noEmit` passed
- `git diff --check` passed
- `bun run test` failed on existing unrelated test/environment issues: Vitest alias resolution for `@/...`, `bun:test` imports under Vitest, and live Feishu/Tavily integration failures
