### PR TITLE
chore: refresh DeepSeek model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/DeepSeek/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/DeepSeek/index.ts
@@ -61,32 +61,6 @@ const models: ProviderConfigType = {
       toolChoice: false,
       showTopP: false,
       showStopSign: false
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'deepseek-v3.2',
-      maxContext: 125000,
-      maxTokens: 32000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1,
-      responseFormatList: ['text', 'json_object'],
-      vision: false,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'deepseek-v3.1',
-      maxContext: 125000,
-      maxTokens: 32000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1,
-      responseFormatList: ['text', 'json_object'],
-      vision: false,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
     }
   ]
 };


### PR DESCRIPTION
## Summary
- remove DeepSeek `deepseek-v3.2` and `deepseek-v3.1` static presets because the official current model docs/list only expose `deepseek-v4-flash` and `deepseek-v4-pro`
- keep `deepseek-chat` and `deepseek-reasoner` because DeepSeek documents them as compatibility aliases until 2026-07-24 15:59 UTC

## Sources
- https://api-docs.deepseek.com/api/list-models
- https://api-docs.deepseek.com/quick_start/pricing

## Validation
- PASS `git diff --check`
- PASS `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider DeepSeek`
- PASS `./node_modules/.bin/eslint packages/infrastructure/src/static-data/models/provider/DeepSeek/index.ts`
- FAIL `./node_modules/.bin/tsc --noEmit` due existing unrelated `sdk/factory` Zod v3/v4 type mismatch (`z.GlobalMeta`, `.meta`, `toJSONSchema`)
- FAIL `./node_modules/.bin/vitest run` at startup due local Rollup native optional dependency code-signing/load error for `@rollup/rollup-darwin-arm64`

Local note: `pnpm` and `bun` were not available in this automation PATH, so validation used the repository's existing `node_modules/.bin` binaries where possible.