### PR TITLE
chore: refresh Mistral model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
@@ -6,9 +6,9 @@ const models: ProviderConfigType = {
     {
       type: ModelTypeEnum.llm,
       model: 'mistral-large-2512',
-      maxContext: 131000,
+      maxContext: 256000,
       maxTokens: 8000,
-      quoteMaxToken: 120000,
+      quoteMaxToken: 240000,
       maxTemperature: 1.2,
       vision: true,
       reasoning: false,
@@ -26,19 +26,6 @@ const models: ProviderConfigType = {
       reasoning: true,
       reasoningEffort: false,
       toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'magistral-small-2509',
-      maxContext: 128000,
-      maxTokens: 32000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1.2,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true,
-      responseFormatList: ['text']
     },
     {
       type: ModelTypeEnum.llm,


### PR DESCRIPTION
## Summary
- update Mistral Large 3 (`mistral-large-2512`) context metadata to match the official 256k model card
- remove deprecated `magistral-small-2509` from the Mistral static presets

## Evidence
- Official Mistral Large 3 model card lists API ID `mistral-large-2512` with 256k context window: https://docs.mistral.ai/models/model-cards/mistral-large-3-25-12
- Official Magistral Small 1.2 model card / overview marks `magistral-small-2509` as deprecated/legacy and points to Mistral Small 4: https://docs.mistral.ai/models/model-cards/magistral-small-1-2-25-09

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider MistralAI`
- `./node_modules/.bin/eslint packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts`
- `git diff --check upstream/main...HEAD`

Known unrelated failures still reproduce:
- `./node_modules/.bin/tsc --noEmit` fails in `sdk/factory` on Zod v3/v4 type mismatch (`z.GlobalMeta`, `.meta`, `toJSONSchema`)
- `./node_modules/.bin/vitest run` has 23 files / 159 tests passing and fails `sdk/factory/src/tool-factory.test.ts:280` with `default.string(...).meta is not a function`; `.env.test` is also missing locally
