### PR TITLE
chore: add Claude Fable 5 preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
@@ -5,6 +5,19 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'claude-fable-5',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 200000,
+      maxTemperature: null,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      showTopP: false
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'claude-opus-4-8',
       maxContext: 1000000,
       maxTokens: 128000,


### PR DESCRIPTION
## Summary

- Add the Claude `claude-fable-5` static LLM preset.
- Keep Groq out of the static preset refresh flow per the existing automation memory rule for third-party provider/catalog sources.
- Audited current official sources for OpenAI, Claude, Gemini, Grok, MistralAI, Qwen, DeepSeek, Moonshot/Kimi, and StepFun; no other static preset changes were needed.

## Evidence

- Anthropic's official models overview lists `claude-fable-5` as generally available from 2026-06-09 with 1M context, 128k max output, vision, adaptive thinking, and effort support.
- `claude-mythos-5` is listed as limited availability, so it was intentionally skipped.
- Source: https://docs.anthropic.com/en/docs/about-claude/models

## Validation

- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/model-provider-plan-20260610.json --dry-run`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/model-provider-plan-20260610.json --write`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs check-sources --provider OpenAI,Claude,Gemini,Grok,MistralAI,Qwen,DeepSeek,Moonshot,StepFun --concurrency 4`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Claude`
- `./node_modules/.bin/eslint packages/infrastructure/src/static-data/models/provider/Claude/index.ts`
- `git diff --check`
- `./node_modules/.bin/tsx -e "import { staticModelList } from './packages/infrastructure/src/static-data/models/index.ts'; const item = staticModelList.find((model) => model.provider === 'Claude' && model.model === 'claude-fable-5'); if (!item) throw new Error('missing claude-fable-5'); console.log(JSON.stringify({ provider: item.provider, model: item.model, maxContext: item.maxContext, maxTokens: item.maxTokens, vision: item.vision, reasoning: item.reasoning, reasoningEffort: item.reasoningEffort, toolChoice: item.toolChoice }));"`

Known unrelated failures still reproduce:

- `./node_modules/.bin/tsc --noEmit` fails in `sdk/factory` on Zod v3/v4 type mismatches such as `z.GlobalMeta`, `.meta`, and `toJSONSchema`.
- `./node_modules/.bin/vitest run` passes 23 files / 159 tests and fails `sdk/factory/src/tool-factory.test.ts:280` with `default.string(...).meta is not a function`; local `.env.test` is also missing.
