### PR TITLE
fix: improve error diagnostics

### DIFF
--- a/apps/cli/src/@type/hono.d.ts
+++ b/apps/cli/src/@type/hono.d.ts
@@ -1,3 +1,4 @@
+import type { HttpRequestBodySnapshot } from '@infrastructure/hono/utils/request-log';
 import type { Logger } from '@infrastructure/logger';
 
 declare global {
@@ -5,6 +6,7 @@ declare global {
     Variables: {
       logger: Logger;
       requestId: string;
+      requestBodySnapshot?: HttpRequestBodySnapshot;
     };
   };
 }

--- a/packages/infrastructure/src/hono/@type/hono.d.ts
+++ b/packages/infrastructure/src/hono/@type/hono.d.ts
@@ -1,10 +1,12 @@
 import type { Logger } from '../../logger';
+import type { HttpRequestBodySnapshot } from '../utils/request-log';
 
 declare global {
   type Env = {
     Variables: {
       logger: Logger;
       requestId: string;
+      requestBodySnapshot?: HttpRequestBodySnapshot;
     };
   };
 }

--- a/packages/infrastructure/src/hono/hooks/onError.ts
+++ b/packages/infrastructure/src/hono/hooks/onError.ts
@@ -1,16 +1,21 @@
 import type { ErrorHandler } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 
-import { createError } from '@domain/value-objects/error.vo';
+import { createError, serializeError } from '@domain/value-objects/error.vo';
 import { ErrorCode } from '@infrastructure/errors/error.registry';
 
+import { buildHttpRequestLogContext } from '../utils/request-log';
 import { R } from '../utils/response';
 
-export const onError: ErrorHandler<Env> = (error, c) => {
+export const onError: ErrorHandler<Env> = async (error, c) => {
+  const requestBodySnapshot = c.get('requestBodySnapshot');
   if (error instanceof HTTPException) {
     const message = error.status === 401 ? 'Unauthorized' : error.message;
     console.warn('HTTP Exception: ', error);
-    c.get('logger').warn(`HTTP Exception: ${JSON.stringify(error, null, 2)}`, { error });
+    c.get('logger').warn(`HTTP Exception: ${message}`, {
+      request: await buildHttpRequestLogContext(c, requestBodySnapshot),
+      error: serializeError(error, { includeStack: true })
+    });
     return R.fail(
       c,
       error.status,
@@ -25,6 +30,9 @@ export const onError: ErrorHandler<Env> = (error, c) => {
     );
   }
   console.error('Internal Server Error: ', error);
-  c.get('logger').error(`Internal Server Error: ${JSON.stringify(error, null, 2)}`, { error });
+  c.get('logger').error(`Internal Server Error: ${serializeError(error).message}`, {
+    request: await buildHttpRequestLogContext(c, requestBodySnapshot),
+    error: serializeError(error, { includeStack: true })
+  });
   return R.fail(c, 500, createError(ErrorCode.internalServerError, { cause: error }));
 };

--- a/packages/infrastructure/src/hono/middleware/logger.ts
+++ b/packages/infrastructure/src/hono/middleware/logger.ts
@@ -1,12 +1,17 @@
 import { createMiddleware } from 'hono/factory';
 
+import { serializeError } from '@domain/value-objects/error.vo';
+
 import { getLogger, http, withContext } from '../../logger';
+import { buildHttpRequestLogContext, createHttpRequestBodySnapshot } from '../utils/request-log';
 
 export const loggerHonoMiddleware = createMiddleware<Env>(async (c, next) => {
   const requestId = c.get('requestId');
   const path = c.req.path;
   const method = c.req.method;
   const start = performance.now();
+  const bodySnapshot = createHttpRequestBodySnapshot(c.req.raw);
+  c.set('requestBodySnapshot', bodySnapshot);
 
   await withContext({ requestId }, async () => {
     const logger = getLogger(http.req).with({
@@ -19,16 +24,40 @@ export const loggerHonoMiddleware = createMiddleware<Env>(async (c, next) => {
 
     logger.info(`[${method}] ${path}`);
 
-    await next();
+    try {
+      await next();
+    } catch (error) {
+      logger.error(`[${method}] ${path} handler failed`, {
+        request: await buildHttpRequestLogContext(c, bodySnapshot),
+        error: serializeError(error, { includeStack: true })
+      });
+      throw error;
+    }
 
     const status = c.res.status;
     const elapsed = (performance.now() - start).toFixed(2);
+    const responseLogger = getLogger(http.res);
 
-    getLogger(http.res).info(`[${method}] ${path} - ${status} ${elapsed}ms`, {
+    responseLogger.info(`[${method}] ${path} - ${status} ${elapsed}ms`, {
       method,
       path,
       status,
       elapsed: `${elapsed}ms`
     });
+
+    if (status >= 400) {
+      const properties = {
+        method,
+        path,
+        status,
+        elapsed: `${elapsed}ms`,
+        request: await buildHttpRequestLogContext(c, bodySnapshot)
+      };
+      if (status >= 500) {
+        responseLogger.error(`[${method}] ${path} failed - ${status} ${elapsed}ms`, properties);
+      } else {
+        responseLogger.warn(`[${method}] ${path} failed - ${status} ${elapsed}ms`, properties);
+      }
+    }
   });
 });

--- a/packages/infrastructure/src/hono/utils/request-log.test.ts
+++ b/packages/infrastructure/src/hono/utils/request-log.test.ts
@@ -1,0 +1,95 @@
+import type { Context } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { buildHttpRequestLogContext, createHttpRequestBodySnapshot } from './request-log';
+
+function createContext(request: Request): Context {
+  const url = new URL(request.url);
+
+  return {
+    req: {
+      url: request.url,
+      method: request.method,
+      path: url.pathname,
+      header: (name: string) => request.headers.get(name) ?? undefined
+    }
+  } as unknown as Context;
+}
+
+describe('request log context', () => {
+  it('captures query parameters for failed GET requests', async () => {
+    const request = new Request(
+      'https://plugin.example.com/api/tool?pluginId=getTime&source=system&tag=tools&tag=search'
+    );
+
+    await expect(
+      buildHttpRequestLogContext(createContext(request), createHttpRequestBodySnapshot(request))
+    ).resolves.toMatchObject({
+      method: 'GET',
+      path: '/api/tool',
+      query: {
+        pluginId: 'getTime',
+        source: 'system',
+        tag: ['tools', 'search']
+      }
+    });
+  });
+
+  it('captures JSON request bodies and redacts secret fields', async () => {
+    const request = new Request('https://plugin.example.com/api/tool/runStream', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        pluginId: 'getTime',
+        input: {
+          timezone: 'Asia/Shanghai'
+        },
+        secrets: {
+          apiKey: 'secret-key'
+        },
+        systemVar: {
+          invokeToken: 'invoke-token'
+        }
+      })
+    });
+
+    await expect(
+      buildHttpRequestLogContext(createContext(request), createHttpRequestBodySnapshot(request))
+    ).resolves.toMatchObject({
+      method: 'POST',
+      path: '/api/tool/runStream',
+      body: {
+        pluginId: 'getTime',
+        input: {
+          timezone: 'Asia/Shanghai'
+        },
+        secrets: '[redacted]',
+        systemVar: {
+          invokeToken: '[redacted]'
+        }
+      }
+    });
+  });
+
+  it('omits multipart file bodies', async () => {
+    const form = new FormData();
+    form.append('files', new Blob(['pkg-content'], { type: 'application/octet-stream' }), 'tool.pkg');
+    const request = new Request('https://plugin.example.com/api/plugin/upload', {
+      method: 'POST',
+      body: form
+    });
+
+    await expect(
+      buildHttpRequestLogContext(createContext(request), createHttpRequestBodySnapshot(request))
+    ).resolves.toMatchObject({
+      method: 'POST',
+      path: '/api/plugin/upload',
+      body: {
+        omitted: true,
+        reason: 'multipart_body_omitted'
+      }
+    });
+  });
+});

--- a/packages/infrastructure/src/hono/utils/request-log.ts
+++ b/packages/infrastructure/src/hono/utils/request-log.ts
@@ -1,0 +1,305 @@
+import type { Context } from 'hono';
+
+import { serializeError } from '@domain/value-objects/error.vo';
+
+const MAX_BODY_CHARS = 64 * 1024;
+const MAX_STRING_CHARS = 4 * 1024;
+
+type BodySnapshot =
+  | {
+      kind: 'empty';
+    }
+  | {
+      kind: 'omitted';
+      reason: string;
+      contentType?: string;
+      contentLength?: number;
+    }
+  | {
+      kind: 'readable';
+      contentType: string;
+      request: Request;
+    };
+
+export type HttpRequestBodySnapshot = {
+  read(): Promise<unknown>;
+};
+
+export type HttpRequestLogContext = {
+  method: string;
+  path: string;
+  query?: unknown;
+  headers: {
+    contentType?: string;
+    contentLength?: string;
+    accept?: string;
+    userAgent?: string;
+  };
+  body?: unknown;
+};
+
+export function createHttpRequestBodySnapshot(request: Request): HttpRequestBodySnapshot {
+  const snapshot = createBodySnapshot(request);
+  let cachedBody: Promise<unknown> | undefined;
+
+  return {
+    read: async () => {
+      cachedBody ??= readBodySnapshot(snapshot);
+      return cachedBody;
+    }
+  };
+}
+
+export async function buildHttpRequestLogContext(
+  c: Context,
+  bodySnapshot?: HttpRequestBodySnapshot
+): Promise<HttpRequestLogContext> {
+  const url = new URL(c.req.url);
+  const query = toQueryObject(url.searchParams);
+  const body = await bodySnapshot?.read();
+
+  return {
+    method: c.req.method,
+    path: c.req.path,
+    ...(Object.keys(query).length > 0 ? { query: redactForLog(query) } : {}),
+    headers: {
+      ...(c.req.header('content-type') ? { contentType: c.req.header('content-type') } : {}),
+      ...(c.req.header('content-length') ? { contentLength: c.req.header('content-length') } : {}),
+      ...(c.req.header('accept') ? { accept: c.req.header('accept') } : {}),
+      ...(c.req.header('user-agent') ? { userAgent: c.req.header('user-agent') } : {})
+    },
+    ...(body !== undefined ? { body } : {})
+  };
+}
+
+function createBodySnapshot(request: Request): BodySnapshot {
+  if (!methodCanHaveBody(request.method)) {
+    return { kind: 'empty' };
+  }
+
+  const contentType = request.headers.get('content-type') ?? '';
+  const contentLength = parseContentLength(request.headers.get('content-length'));
+
+  if (!contentType && !contentLength) {
+    return { kind: 'empty' };
+  }
+
+  if (contentLength !== undefined && contentLength > MAX_BODY_CHARS) {
+    return {
+      kind: 'omitted',
+      reason: 'body_too_large',
+      contentType,
+      contentLength
+    };
+  }
+
+  if (isMultipart(contentType)) {
+    return {
+      kind: 'omitted',
+      reason: 'multipart_body_omitted',
+      contentType,
+      contentLength
+    };
+  }
+
+  if (!isReadableContentType(contentType)) {
+    return {
+      kind: 'omitted',
+      reason: 'unsupported_body_content_type',
+      contentType,
+      contentLength
+    };
+  }
+
+  return {
+    kind: 'readable',
+    contentType,
+    request: request.clone()
+  };
+}
+
+async function readBodySnapshot(snapshot: BodySnapshot): Promise<unknown> {
+  if (snapshot.kind === 'empty') {
+    return undefined;
+  }
+
+  if (snapshot.kind === 'omitted') {
+    return {
+      omitted: true,
+      reason: snapshot.reason,
+      ...(snapshot.contentType ? { contentType: snapshot.contentType } : {}),
+      ...(snapshot.contentLength !== undefined ? { contentLength: snapshot.contentLength } : {})
+    };
+  }
+
+  try {
+    const { text, truncated } = await readBodyText(snapshot.request);
+    if (!text) {
+      return undefined;
+    }
+
+    if (truncated || text.length > MAX_BODY_CHARS) {
+      return {
+        omitted: true,
+        reason: 'body_too_large',
+        contentType: snapshot.contentType,
+        preview: text.slice(0, MAX_STRING_CHARS)
+      };
+    }
+
+    return parseBodyText(text, snapshot.contentType);
+  } catch (error) {
+    return {
+      omitted: true,
+      reason: 'body_read_failed',
+      error: serializeError(error)
+    };
+  }
+}
+
+function parseBodyText(text: string, contentType: string): unknown {
+  if (isJson(contentType)) {
+    try {
+      return redactForLog(JSON.parse(text));
+    } catch {
+      return redactForLog(text);
+    }
+  }
+
+  if (contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
+    return redactForLog(toQueryObject(new URLSearchParams(text)));
+  }
+
+  return redactForLog(text);
+}
+
+function toQueryObject(searchParams: URLSearchParams): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+
+  for (const [key, value] of searchParams.entries()) {
+    const current = result[key];
+    if (current === undefined) {
+      result[key] = value;
+      continue;
+    }
+    result[key] = Array.isArray(current) ? [...current, value] : [current, value];
+  }
+
+  return result;
+}
+
+function redactForLog(value: unknown, key?: string, depth = 0): unknown {
+  if (key && isSensitiveKey(key)) {
+    return '[redacted]';
+  }
+
+  if (isFileLike(value)) {
+    return '[omitted:file]';
+  }
+
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_CHARS ? `${value.slice(0, MAX_STRING_CHARS)}...` : value;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (depth > 8) {
+    return '[omitted:max-depth]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactForLog(item, key, depth + 1));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([entryKey, entryValue]) => [
+      entryKey,
+      redactForLog(entryValue, entryKey, depth + 1)
+    ])
+  );
+}
+
+function methodCanHaveBody(method: string): boolean {
+  return !['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase());
+}
+
+function isReadableContentType(contentType: string): boolean {
+  const normalizedContentType = contentType.toLowerCase();
+  return (
+    isJson(normalizedContentType) ||
+    normalizedContentType.includes('application/x-www-form-urlencoded') ||
+    normalizedContentType.startsWith('text/')
+  );
+}
+
+function isJson(contentType: string): boolean {
+  const normalizedContentType = contentType.toLowerCase();
+  return normalizedContentType.includes('application/json') || normalizedContentType.includes('+json');
+}
+
+function isMultipart(contentType: string): boolean {
+  return contentType.toLowerCase().includes('multipart/form-data');
+}
+
+function parseContentLength(contentLength: string | null): number | undefined {
+  if (!contentLength) {
+    return undefined;
+  }
+
+  const parsed = Number(contentLength);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /^(authorization|token|accessToken|refreshToken|apiKey|api_key|secret|secrets|password|privateKey|invokeToken)$/i.test(
+    key
+  );
+}
+
+function isFileLike(value: unknown): boolean {
+  return (
+    (typeof File !== 'undefined' && value instanceof File) ||
+    (typeof Blob !== 'undefined' && value instanceof Blob) ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value) ||
+    (typeof ReadableStream !== 'undefined' && value instanceof ReadableStream)
+  );
+}
+
+async function readBodyText(request: Request): Promise<{ text: string; truncated: boolean }> {
+  if (!request.body) {
+    return {
+      text: await request.text(),
+      truncated: false
+    };
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let truncated = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      text += decoder.decode(value, { stream: true });
+      if (text.length > MAX_BODY_CHARS) {
+        truncated = true;
+        await reader.cancel().catch(() => undefined);
+        break;
+      }
+    }
+
+    text += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { text, truncated };
+}

--- a/packages/infrastructure/src/hono/utils/response.test.ts
+++ b/packages/infrastructure/src/hono/utils/response.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import z from 'zod';
 
 import { createError } from '@domain/value-objects/error.vo';
 import { failureResult } from '@domain/value-objects/result.vo';
@@ -102,6 +103,78 @@ describe('R.fail', () => {
               en: 'Plugin not found',
               'zh-CN': '插件未找到'
             }
+          }
+        }
+      }
+    });
+  });
+
+  it('returns readable validation errors with issue details', () => {
+    const schema = z.object({
+      pluginId: z.string()
+    });
+    const result = schema.safeParse({});
+
+    if (result.success) {
+      throw new Error('Expected validation failure');
+    }
+
+    const response = R.fail(createContext(), 400, result.error);
+
+    expect(response).toMatchObject({
+      status: 400,
+      body: {
+        error: {
+          code: ErrorCode.validationFailed,
+          message: expect.stringContaining('Validation failed: pluginId:'),
+          reason: {
+            en: expect.stringContaining('Validation failed: pluginId:'),
+            'zh-CN': expect.stringContaining('请求参数校验失败: pluginId:')
+          },
+          data: {
+            issues: [
+              expect.objectContaining({
+                path: 'pluginId',
+                message: expect.any(String),
+                code: expect.any(String)
+              })
+            ]
+          }
+        }
+      }
+    });
+    expect(
+      (response as unknown as { body: { error: Record<string, unknown> } }).body.error
+    ).not.toHaveProperty('cause');
+  });
+
+  it('keeps validation type errors distinct from missing required fields', () => {
+    const schema = z.object({
+      pluginId: z.string()
+    });
+    const result = schema.safeParse({ pluginId: 1 });
+
+    if (result.success) {
+      throw new Error('Expected validation failure');
+    }
+
+    const response = R.fail(createContext(), 400, result.error);
+
+    expect(response).toMatchObject({
+      status: 400,
+      body: {
+        error: {
+          code: ErrorCode.validationFailed,
+          reason: {
+            'zh-CN': expect.stringContaining('pluginId: 类型错误，应为 string')
+          },
+          data: {
+            issues: [
+              expect.objectContaining({
+                path: 'pluginId',
+                message: expect.stringContaining('received number')
+              })
+            ]
           }
         }
       }

--- a/packages/infrastructure/src/hono/utils/response.ts
+++ b/packages/infrastructure/src/hono/utils/response.ts
@@ -89,16 +89,12 @@ export function appendHeaders(headers: Headers, appendHeaders?: HeadersInit) {
 }
 
 function zodErrorToI18nString(error: z.ZodError): I18nStringType {
-  const details = error.issues
-    .map((issue) => {
-      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
-      return `${path}: ${issue.message}`;
-    })
-    .join('; ');
+  const englishDetails = error.issues.map(formatValidationIssueEn).join('; ');
+  const chineseDetails = error.issues.map(formatValidationIssueZh).join('; ');
 
   return {
-    en: details ? `Validation failed: ${details}` : 'Validation failed',
-    'zh-CN': details ? `数据校验失败: ${details}` : '数据校验失败'
+    en: englishDetails ? `Validation failed: ${englishDetails}` : 'Validation failed',
+    'zh-CN': chineseDetails ? `请求参数校验失败: ${chineseDetails}` : '请求参数校验失败'
   };
 }
 
@@ -107,14 +103,7 @@ function normalizeError(
   error: I18nStringType | z.ZodError | string | Error
 ): ErrorResponseType {
   if (error instanceof z.ZodError) {
-    const reason = zodErrorToI18nString(error);
-    return toErrorResponse(
-      createError(ErrorCode.validationFailed, {
-        message: reason.en,
-        reason,
-        cause: error
-      })
-    );
+    return toErrorResponse(createValidationError(error));
   }
 
   if (error instanceof Error) {
@@ -206,26 +195,60 @@ function buildQueryTarget(c: Context) {
 }
 
 function validationErrorResponse(c: Context, error: z.ZodError) {
-  const issues = error.issues;
-  if (issues.length === 0) {
-    return R.fail(c, 400, {
-      en: 'Unknown validation error',
-      'zh-CN': '未知数据校验错误'
-    });
-  }
+  return R.fail(c, 400, createValidationError(error));
+}
 
-  const paths = [];
-  for (const issue of issues) {
-    if (issue.path) {
-      paths.push(...issue.path.flat());
+function createValidationError(error: z.ZodError): Error {
+  const reason = zodErrorToI18nString(error);
+
+  return createError(ErrorCode.validationFailed, {
+    message: reason.en,
+    reason,
+    data: {
+      issues: error.issues.map(toValidationIssue)
+    }
+  });
+}
+
+function toValidationIssue(issue: z.core.$ZodIssue): Record<string, unknown> {
+  const issueRecord = issue as z.core.$ZodIssue & Record<string, unknown>;
+  const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+
+  return {
+    path,
+    message: issue.message,
+    code: issue.code,
+    ...(issueRecord.expected !== undefined ? { expected: issueRecord.expected } : {}),
+    ...(issueRecord.received !== undefined ? { received: issueRecord.received } : {}),
+    ...(issueRecord.options !== undefined ? { options: issueRecord.options } : {}),
+    ...(issueRecord.minimum !== undefined ? { minimum: issueRecord.minimum } : {}),
+    ...(issueRecord.maximum !== undefined ? { maximum: issueRecord.maximum } : {})
+  };
+}
+
+function formatValidationIssueEn(issue: z.core.$ZodIssue): string {
+  return `${getIssuePath(issue)}: ${issue.message}`;
+}
+
+function formatValidationIssueZh(issue: z.core.$ZodIssue): string {
+  const issueRecord = issue as z.core.$ZodIssue & Record<string, unknown>;
+  const path = getIssuePath(issue);
+
+  if (issue.code === 'invalid_type') {
+    const expected = issueRecord.expected;
+    if (issue.message.includes('received undefined')) {
+      return `${path}: 缺少必填字段`;
+    }
+    if (typeof expected === 'string') {
+      return `${path}: 类型错误，应为 ${expected}`;
     }
   }
-  const fields = Array.from(new Set(paths)).filter(isNotNil).join(', ');
 
-  return R.fail(c, 400, {
-    en: fields || 'Validation failed',
-    'zh-CN': fields || '数据校验失败'
-  });
+  return `${path}: ${issue.message}`;
+}
+
+function getIssuePath(issue: z.core.$ZodIssue): string {
+  return issue.path.length > 0 ? issue.path.join('.') : '(root)';
 }
 
 async function validateRequest(c: Context, route: OpenAPIRouteDefinition) {

--- a/packages/usecase/src/log-error.ts
+++ b/packages/usecase/src/log-error.ts
@@ -1,0 +1,71 @@
+import { serializeError } from '@domain/value-objects/error.vo';
+import type { ResultFailure } from '@domain/value-objects/result.vo';
+
+export function toUsecaseErrorLog(
+  failure: ResultFailure,
+  context: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return redactForLog({
+    ...context,
+    reason: failure.reason,
+    ...(failure.code !== undefined ? { code: failure.code } : {}),
+    ...(failure.message !== undefined ? { message: failure.message } : {}),
+    ...(failure.data !== undefined ? { data: failure.data } : {}),
+    error: serializeError(failure.error, { includeStack: true })
+  }) as Record<string, unknown>;
+}
+
+export function isResultFailure(value: unknown): value is ResultFailure {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'reason' in value &&
+      'error' in value &&
+      (value as { error?: unknown }).error instanceof Error
+  );
+}
+
+function redactForLog(value: unknown, key?: string, depth = 0): unknown {
+  if (key && isSensitiveKey(key)) {
+    return '[redacted]';
+  }
+
+  if (isFileLike(value)) {
+    return '[omitted:file]';
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (depth > 8) {
+    return '[omitted:max-depth]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactForLog(item, key, depth + 1));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([entryKey, entryValue]) => [
+      entryKey,
+      redactForLog(entryValue, entryKey, depth + 1)
+    ])
+  );
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /^(authorization|token|accessToken|refreshToken|apiKey|api_key|secret|secrets|password|privateKey|invokeToken)$/i.test(
+    key
+  );
+}
+
+function isFileLike(value: unknown): boolean {
+  return (
+    (typeof File !== 'undefined' && value instanceof File) ||
+    (typeof Blob !== 'undefined' && value instanceof Blob) ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value) ||
+    (typeof ReadableStream !== 'undefined' && value instanceof ReadableStream)
+  );
+}

--- a/packages/usecase/src/model/model-list.uc.ts
+++ b/packages/usecase/src/model/model-list.uc.ts
@@ -8,6 +8,7 @@
 import type { ModelItemType } from '@domain/entities/model.entity';
 import type { ModelManagerPort } from '@domain/ports/plugin/model.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 /** Dependencies */
 export type ModelListDeps = {
@@ -27,7 +28,7 @@ export const makeModelListUC =
     logger.debug('Model List');
     const [result, error] = await modelManager.models();
     if (error) {
-      logger.error('Model List Error', error);
+      logger.error('Model List Error', toUsecaseErrorLog(error));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/model/providers.uc.ts
+++ b/packages/usecase/src/model/providers.uc.ts
@@ -8,6 +8,7 @@
 import type { ModelProviderType } from '@domain/entities/model.entity';
 import type { ModelManagerPort } from '@domain/ports/plugin/model.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 /** Dependencies */
 export type ProviderListDeps = {
@@ -27,7 +28,7 @@ export const makeProviderListUC =
     logger.debug('Provider List', { input });
     const [result, error] = await modelManager.providers();
     if (error) {
-      logger.error('Provider List Error', error);
+      logger.error('Provider List Error', toUsecaseErrorLog(error, { input }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-config-get.uc.ts
+++ b/packages/usecase/src/plugin/plugin-config-get.uc.ts
@@ -8,6 +8,7 @@
 import type { PluginRuntimeConfigType } from '@domain/entities/plugin.entity';
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 /** Dependencies */
@@ -30,7 +31,7 @@ export const makePluginConfigGetUC =
     logger.debug('Plugin Config Get', { pluginId });
     const [result, error] = await pluginRuntimeManager.getConfig(pluginId);
     if (error) {
-      logger.error('Plugin Config Get Error', error);
+      logger.error('Plugin Config Get Error', toUsecaseErrorLog(error, { pluginId }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-config-reset.uc.ts
+++ b/packages/usecase/src/plugin/plugin-config-reset.uc.ts
@@ -6,6 +6,7 @@
  */
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 /** Dependencies */
@@ -28,7 +29,7 @@ export const makeResetPluginConfigUC =
     logger.debug('Plugin Config Reset', { pluginId });
     const [result, error] = await pluginRuntimeManager.resetConfig(pluginId);
     if (error) {
-      logger.error('Plugin Config Reset Error', error);
+      logger.error('Plugin Config Reset Error', toUsecaseErrorLog(error, { pluginId }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-config-set.uc.ts
+++ b/packages/usecase/src/plugin/plugin-config-set.uc.ts
@@ -7,6 +7,7 @@
 import type { PluginRuntimeConfigType } from '@domain/entities/plugin.entity';
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 /** Dependencies */
@@ -30,7 +31,7 @@ export const makeSetPluginConfigUC =
     logger.debug('Plugin Config Set', { input });
     const [result, error] = await pluginRuntimeManager.updateConfig(input.pluginId, input.config);
     if (error) {
-      logger.error('Plugin Config Set Error', error);
+      logger.error('Plugin Config Set Error', toUsecaseErrorLog(error, { input }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-confirm.uc.ts
+++ b/packages/usecase/src/plugin/plugin-confirm.uc.ts
@@ -11,6 +11,7 @@ import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import type { PluginUniqueIdType } from '@domain/value-objects/plugin.vo';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 import {
@@ -49,7 +50,7 @@ export const makePluginConfirmUC =
       if (replacedErr) {
         deps.logger.error('Plugin Confirm Replaced Active List Error', {
           uniqueId,
-          error: replacedErr
+          error: toUsecaseErrorLog(replacedErr)
         });
         return failureResult(
           {
@@ -66,7 +67,7 @@ export const makePluginConfirmUC =
       if (pendingErr) {
         deps.logger.error('Plugin Confirm Pending List Error', {
           uniqueId,
-          error: pendingErr
+          error: toUsecaseErrorLog(pendingErr)
         });
         return failureResult(
           {
@@ -91,7 +92,7 @@ export const makePluginConfirmUC =
       if (err) {
         deps.logger.error('Plugin Confirm One Error', {
           uniqueId,
-          error: err
+          error: toUsecaseErrorLog(err)
         });
         return failureResult(
           {
@@ -108,7 +109,7 @@ export const makePluginConfirmUC =
         if (registerErr) {
           deps.logger.error('Plugin Confirm Register Runtime Error', {
             uniqueId,
-            error: registerErr
+            error: toUsecaseErrorLog(registerErr)
           });
           return failureResult(
             {
@@ -128,7 +129,7 @@ export const makePluginConfirmUC =
         if (replaceErr) {
           deps.logger.error('Plugin Confirm Replace Active Error', {
             uniqueId,
-            error: replaceErr
+            error: toUsecaseErrorLog(replaceErr)
           });
           return failureResult(replaceErr);
         }
@@ -148,7 +149,7 @@ export const makePluginConfirmUC =
       if (err) {
         deps.logger.error('Plugin Confirm Error', {
           uniqueId,
-          error: err
+          error: toUsecaseErrorLog(err)
         });
         return failureResult(err);
       }

--- a/packages/usecase/src/plugin/plugin-delete.uc.ts
+++ b/packages/usecase/src/plugin/plugin-delete.uc.ts
@@ -2,6 +2,7 @@ import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { PluginUniqueIdSchema, type UserPluginIdType } from '@domain/value-objects/plugin.vo';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { isResultFailure, toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export type PluginDeleteUCDeps = {
@@ -20,7 +21,7 @@ export const makePluginDeleteUC =
     const [plugin, pluginErr] = await pluginRepo.getPluginByUserPluginId(input);
 
     if (pluginErr) {
-      logger.error('Plugin Delete Detail Error', pluginErr);
+      logger.error('Plugin Delete Detail Error', toUsecaseErrorLog(pluginErr, { input }));
       return failureResult(
         {
           en: 'Plugin not found',
@@ -36,7 +37,7 @@ export const makePluginDeleteUC =
     if (disableErr) {
       logger.error('Plugin Delete Disable Error', {
         uniqueId,
-        error: disableErr
+        error: toUsecaseErrorLog(disableErr)
       });
       return failureResult(
         {
@@ -62,7 +63,7 @@ export const makePluginDeleteUC =
           source: input.source,
           version: uniqueId.version,
           etag: uniqueId.etag,
-          error: unregisterErr
+          error: isResultFailure(unregisterErr) ? toUsecaseErrorLog(unregisterErr) : unregisterErr
         });
       }
     }

--- a/packages/usecase/src/plugin/plugin-list.uc.ts
+++ b/packages/usecase/src/plugin/plugin-list.uc.ts
@@ -11,6 +11,7 @@ import type {
   PluginRepoPort
 } from '@domain/ports/plugin/plugin-repo.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 /** Dependencies */
 type Deps = {
@@ -30,7 +31,7 @@ export const makePluginListUC =
     logger.debug('Plugin List', { input });
     const [result, error] = await pluginRepo.list(input);
     if (error) {
-      logger.error('Plugin List Error', error);
+      logger.error('Plugin List Error', toUsecaseErrorLog(error, { input }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-prune-disabled.uc.ts
+++ b/packages/usecase/src/plugin/plugin-prune-disabled.uc.ts
@@ -1,5 +1,6 @@
 import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
 import { failureResult, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export type PluginPruneDisabledUCDeps = {
@@ -13,7 +14,7 @@ export const makePluginPruneDisabledUC =
     logger.debug('Plugin Prune Disabled');
     const [result, error] = await pluginRepo.pruneDisabled();
     if (error) {
-      logger.error('Plugin Prune Disabled Error', error);
+      logger.error('Plugin Prune Disabled Error', toUsecaseErrorLog(error));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-register-active.uc.ts
+++ b/packages/usecase/src/plugin/plugin-register-active.uc.ts
@@ -3,6 +3,7 @@ import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { PluginUniqueIdSchema } from '@domain/value-objects/plugin.vo';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export type PluginRegisterActiveUCDeps = {
@@ -22,7 +23,7 @@ export const makePluginRegisterActiveUC =
     const [plugins, listErr] = await deps.pluginRepo.listActive();
 
     if (listErr) {
-      deps.logger.error('Plugin Register Active List Error', listErr);
+      deps.logger.error('Plugin Register Active List Error', toUsecaseErrorLog(listErr));
       return failureResult(
         {
           en: 'Failed to get active plugins',
@@ -46,7 +47,7 @@ export const makePluginRegisterActiveUC =
       if (registerErr) {
         deps.logger.error('Plugin Register Active One Error', {
           uniqueId,
-          error: registerErr
+          error: toUsecaseErrorLog(registerErr)
         });
         return failureResult(
           {

--- a/packages/usecase/src/plugin/plugin-replace-active.ts
+++ b/packages/usecase/src/plugin/plugin-replace-active.ts
@@ -3,6 +3,7 @@ import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { PluginUniqueIdSchema, type PluginUniqueIdType } from '@domain/value-objects/plugin.vo';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export const listReplacedActivePlugins = async (
@@ -57,7 +58,7 @@ export const disableAndUnregisterReplacedPlugins = async (deps: {
     )[1]!;
     deps.logger.error('Plugin Replace Active Disable Error', {
       replacedPluginIds,
-      error: failure.error
+      error: toUsecaseErrorLog(failure)
     });
     return [null, failure];
   }
@@ -73,7 +74,7 @@ export const disableAndUnregisterReplacedPlugins = async (deps: {
             pluginId: uniqueId.pluginId,
             version: uniqueId.version,
             etag: uniqueId.etag,
-            error: unregisterErr
+            error: toUsecaseErrorLog(unregisterErr)
           });
         }
       } catch (error) {

--- a/packages/usecase/src/plugin/plugin-tag-list.uc.ts
+++ b/packages/usecase/src/plugin/plugin-tag-list.uc.ts
@@ -9,6 +9,7 @@
 import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
 import type { PluginTagListType } from '@domain/value-objects/plugin.vo';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 /** Dependencies */
 type Deps = {
@@ -29,7 +30,7 @@ export const makePluginTagListUC =
     logger.debug('Plugin Tag List');
     const [result, error] = await pluginRepo.listTags();
     if (error) {
-      logger.error('Plugin Tag List Error', error);
+      logger.error('Plugin Tag List Error', toUsecaseErrorLog(error));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/plugin/plugin-upload.uc.ts
+++ b/packages/usecase/src/plugin/plugin-upload.uc.ts
@@ -10,6 +10,7 @@ import type { PkgContentFileObjects } from '@domain/value-objects/file/pkg-file.
 import type { I18nStringType } from '@domain/value-objects/i18n-string.vo';
 import { PluginUniqueIdSchema, type PluginUniqueIdType } from '@domain/value-objects/plugin.vo';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export type PluginUploadUCDeps = {
@@ -83,7 +84,7 @@ const rollbackPendingPlugins = async (
     if (err) {
       deps.logger.warn('Failed to rollback pending plugin', {
         uniqueId,
-        reason: err.reason
+        error: toUsecaseErrorLog(err)
       });
     }
   }
@@ -119,7 +120,7 @@ export const makePluginUploadUC =
     const [existingPendingPlugins, pendingErr] = await deps.pluginRepo.getPendingPluginIds();
 
     if (pendingErr) {
-      logger.error('Plugin Upload Pending List Error', pendingErr);
+      logger.error('Plugin Upload Pending List Error', toUsecaseErrorLog(pendingErr));
       return failureResult(
         {
           en: 'Failed to get pending plugin ids',

--- a/packages/usecase/src/plugin/plugin-versions.uc.ts
+++ b/packages/usecase/src/plugin/plugin-versions.uc.ts
@@ -11,6 +11,7 @@ import type {
   PluginVersionListOutputType
 } from '@domain/ports/plugin/plugin-repo.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 type PluginVersionsDeps = {
@@ -28,7 +29,7 @@ export const makePluginVersionsUC =
     logger.debug('Plugin Versions', { input });
     const [result, error] = await pluginRepo.listVersions(input);
     if (error) {
-      logger.error('Plugin Versions Error', error);
+      logger.error('Plugin Versions Error', toUsecaseErrorLog(error, { input }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/runtime/runtime-metrics.uc.ts
+++ b/packages/usecase/src/runtime/runtime-metrics.uc.ts
@@ -7,6 +7,7 @@
 
 import type { PluginRuntimeManagerPort } from '@domain/ports/plugin/plugin-runtime-manager.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 /** Dependencies */
 export type RuntimeMetricsUCDeps = {
@@ -26,7 +27,7 @@ export const makeRuntimeMetricsUC =
     logger.debug('Runtime Metrics');
     const [result, error] = await pluginRuntimeManager.globalStatus();
     if (error) {
-      logger.error('Runtime Metrics Error', error);
+      logger.error('Runtime Metrics Error', toUsecaseErrorLog(error));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/tool/tool-detail.uc.ts
+++ b/packages/usecase/src/tool/tool-detail.uc.ts
@@ -11,6 +11,7 @@ import type {
   ToolManagerPort
 } from '@domain/ports/plugin/tool.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export type ToolDetailUCDeps = {
@@ -27,7 +28,7 @@ export const makeToolDetailUC =
     logger.debug('Tool Detail', { input });
     const [result, error] = await toolManager.detail(input);
     if (error) {
-      logger.error('Tool Detail Error', error);
+      logger.error('Tool Detail Error', toUsecaseErrorLog(error, { input }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/tool/tool-list.uc.ts
+++ b/packages/usecase/src/tool/tool-list.uc.ts
@@ -11,6 +11,7 @@ import type {
   ToolManagerPort
 } from '@domain/ports/plugin/tool.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 export type ToolListUCDeps = {
@@ -27,7 +28,7 @@ export const makeToolListUC =
     logger.debug('Tool List', { input });
     const [result, error] = await toolManager.list(input);
     if (error) {
-      logger.error('Tool List Error', error);
+      logger.error('Tool List Error', toUsecaseErrorLog(error, { input }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/tool/tool-run.uc.ts
+++ b/packages/usecase/src/tool/tool-run.uc.ts
@@ -9,6 +9,7 @@ import type { ToolManagerPort } from '@domain/ports/plugin/tool.port';
 import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
 import type { StreamData } from '@domain/value-objects/stream.vo';
 import type { ToolRunInputType, ToolStreamMessageType } from '@domain/value-objects/tool.vo';
+import { toUsecaseErrorLog } from '@usecase/log-error';
 import type { UsecaseLogger } from '@usecase/logger.port';
 
 /** Dependencies */
@@ -25,10 +26,7 @@ export const makeToolRunUC =
     logger.debug('Tool Run', { input: toToolRunLogInput(input) });
     const [result, error] = await toolManager.run(input);
     if (error) {
-      logger.error('Tool Run Error', {
-        ...error,
-        input: toToolRunLogInput(input)
-      });
+      logger.error('Tool Run Error', toUsecaseErrorLog(error, { input: toToolRunLogInput(input) }));
       return failureResult(error);
     }
     return successResult(result);

--- a/packages/usecase/src/usecase.test.ts
+++ b/packages/usecase/src/usecase.test.ts
@@ -261,13 +261,25 @@ describe('simple usecases', () => {
       makeToolListUC({ toolManager, logger: usecaseLogger })({ tags: ['tools'] })
     ).resolves.toEqual(result);
 
-    expect(usecaseLogger.error).toHaveBeenCalledWith('Tool List Error', result[1]);
+    expect(usecaseLogger.error).toHaveBeenCalledWith(
+      'Tool List Error',
+      expect.objectContaining({
+        input: { tags: ['tools'] },
+        reason: result[1]?.reason,
+        message: 'list failed',
+        error: expect.objectContaining({
+          name: 'Error',
+          message: 'list failed'
+        })
+      })
+    );
   });
 
   it.each([
     {
       name: 'runtime metrics',
       message: 'Runtime Metrics Error',
+      expectedErrorContext: {},
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeRuntimeMetricsUC({
           pluginRuntimeManager: baseRuntimeManager({
@@ -279,6 +291,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin config get',
       message: 'Plugin Config Get Error',
+      expectedErrorContext: { pluginId: 'plugin-a' },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makePluginConfigGetUC({
           pluginRuntimeManager: baseRuntimeManager({
@@ -290,6 +303,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin config set',
       message: 'Plugin Config Set Error',
+      expectedErrorContext: { input: { pluginId: 'plugin-a', config: { mode: 'local' } } },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeSetPluginConfigUC({
           pluginRuntimeManager: baseRuntimeManager({
@@ -301,6 +315,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin config reset',
       message: 'Plugin Config Reset Error',
+      expectedErrorContext: { pluginId: 'plugin-a' },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeResetPluginConfigUC({
           pluginRuntimeManager: baseRuntimeManager({
@@ -312,6 +327,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin list',
       message: 'Plugin List Error',
+      expectedErrorContext: { input: { tags: ['tools'] } },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makePluginListUC({
           pluginRepo: basePluginRepo({
@@ -323,6 +339,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin versions',
       message: 'Plugin Versions Error',
+      expectedErrorContext: { input: { pluginId: 'plugin-a', source: 'system' } },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makePluginVersionsUC({
           pluginRepo: basePluginRepo({
@@ -334,6 +351,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin tag list',
       message: 'Plugin Tag List Error',
+      expectedErrorContext: {},
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makePluginTagListUC({
           pluginRepo: basePluginRepo({
@@ -345,6 +363,7 @@ describe('simple usecases', () => {
     {
       name: 'plugin prune disabled',
       message: 'Plugin Prune Disabled Error',
+      expectedErrorContext: {},
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makePluginPruneDisabledUC({
           pluginRepo: basePluginRepo({
@@ -356,6 +375,7 @@ describe('simple usecases', () => {
     {
       name: 'model list',
       message: 'Model List Error',
+      expectedErrorContext: {},
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeModelListUC({
           modelManager: baseModelManager({
@@ -367,6 +387,7 @@ describe('simple usecases', () => {
     {
       name: 'provider list',
       message: 'Provider List Error',
+      expectedErrorContext: { input: {} },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeProviderListUC({
           modelManager: baseModelManager({
@@ -378,6 +399,7 @@ describe('simple usecases', () => {
     {
       name: 'tool detail',
       message: 'Tool Detail Error',
+      expectedErrorContext: { input: { pluginId: 'plugin-a', source: 'system' } },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeToolDetailUC({
           toolManager: baseToolManager({
@@ -389,23 +411,19 @@ describe('simple usecases', () => {
     {
       name: 'tool run',
       message: 'Tool Run Error',
-      expectedErrorLog: (result: ReturnType<typeof failureResult>) => [
-        'Tool Run Error',
-        {
-          ...result[1],
-          input: {
-            pluginId: 'plugin-a',
-            source: 'system',
-            input: {},
-            hasSecrets: false,
-            systemVar: {
-              app: { id: 'app', name: 'app' },
-              chat: { chatId: 'chat' },
-              time: '2026-01-01T00:00:00Z'
-            }
+      expectedErrorContext: {
+        input: {
+          pluginId: 'plugin-a',
+          source: 'system',
+          input: {},
+          hasSecrets: false,
+          systemVar: {
+            app: { id: 'app', name: 'app' },
+            chat: { chatId: 'chat' },
+            time: '2026-01-01T00:00:00Z'
           }
         }
-      ],
+      },
       run: (result: ReturnType<typeof failureResult>, usecaseLogger: UsecaseLogger) =>
         makeToolRunUC({
           toolManager: baseToolManager({
@@ -423,14 +441,65 @@ describe('simple usecases', () => {
           }
         })
     }
-  ])('records usecase error logs for $name failures', async ({ message, run, expectedErrorLog }) => {
+  ])(
+    'records usecase error logs for $name failures',
+    async ({ message, run, expectedErrorContext }) => {
     const result = failureResult(reason(`${message} failed`));
     const usecaseLogger = logger();
 
     await expect(run(result, usecaseLogger)).resolves.toEqual(result);
 
+      expect(usecaseLogger.error).toHaveBeenCalledWith(
+        message,
+        expect.objectContaining({
+          ...expectedErrorContext,
+          reason: reason(`${message} failed`),
+          message: `${message} failed`,
+          error: expect.objectContaining({
+            name: 'Error',
+            message: `${message} failed`
+          })
+        })
+      );
+    }
+  );
+
+  it('records tool detail input and nested error cause details', async () => {
+    const cause = new Error('database timeout while reading getTime');
+    const result = failureResult(reason('Failed to get tool detail'), cause);
+    const usecaseLogger = logger();
+
+    await expect(
+      makeToolDetailUC({
+        toolManager: baseToolManager({
+          detail: vi.fn().mockResolvedValue(result)
+        }),
+        logger: usecaseLogger
+      })({
+        pluginId: 'getTime',
+        source: 'system',
+        version: '9.9.9',
+        fallbackLatestVersion: true
+      })
+    ).resolves.toEqual(result);
+
     expect(usecaseLogger.error).toHaveBeenCalledWith(
-      ...(expectedErrorLog?.(result) ?? [message, result[1]])
+      'Tool Detail Error',
+      expect.objectContaining({
+        input: {
+          pluginId: 'getTime',
+          source: 'system',
+          version: '9.9.9',
+          fallbackLatestVersion: true
+        },
+        reason: reason('Failed to get tool detail'),
+        error: expect.objectContaining({
+          message: 'Failed to get tool detail',
+          cause: expect.objectContaining({
+            message: 'database timeout while reading getTime'
+          })
+        })
+      })
     );
   });
 
@@ -468,9 +537,22 @@ describe('simple usecases', () => {
       })
     ).resolves.toEqual(result);
 
-    expect(usecaseLogger.error).toHaveBeenCalledWith('Tool Run Error', {
-      ...result[1],
-      input: {
+    expect(usecaseLogger.error).toHaveBeenCalledWith(
+      'Tool Run Error',
+      expect.objectContaining({
+        reason: result[1]?.reason,
+        code: 'plugin.invoke.timeout',
+        message: 'Plugin invocation timed out',
+        data: {
+          pluginId: 'plugin-a',
+          version: '1.0.0',
+          input: { timezone: 'Asia/Shanghai' }
+        },
+        error: expect.objectContaining({
+          name: 'Error',
+          message: 'Plugin invocation timed out'
+        }),
+        input: {
         pluginId: 'plugin-a',
         source: 'system',
         version: '1.0.0',
@@ -482,7 +564,8 @@ describe('simple usecases', () => {
           time: '2026-01-01T00:00:00Z'
         }
       }
-    });
+      })
+    );
   });
 });
 
@@ -841,10 +924,19 @@ describe('makePluginUploadUC', () => {
 
     expect(err).toBeNull();
     expect(uploaded?.failed?.[0]?.reason.en).toBe('create failed');
-    expect(appLogger.warn).toHaveBeenCalledWith('Failed to rollback pending plugin', {
-      uniqueId,
-      reason: reason('rollback failed')
-    });
+    expect(appLogger.warn).toHaveBeenCalledWith(
+      'Failed to rollback pending plugin',
+      expect.objectContaining({
+        uniqueId,
+        error: expect.objectContaining({
+          reason: reason('rollback failed'),
+          message: 'rollback failed',
+          error: expect.objectContaining({
+            message: 'rollback failed'
+          })
+        })
+      })
+    );
   });
 
   it('does not delete pending plugins that existed before the upload batch', async () => {
@@ -1691,10 +1783,25 @@ describe('plugin replacement helpers', () => {
     const [, err] = await disableAndUnregisterReplacedPlugins(deps);
 
     expect(err?.reason.en).toBe('Failed to disable replaced plugins');
-    expect(appLogger.error).toHaveBeenCalledWith('Plugin Replace Active Disable Error', {
-      replacedPluginIds: [{ ...uniqueId, etag: 'old' }],
-      error: err?.error
-    });
+    expect(appLogger.error).toHaveBeenCalledWith(
+      'Plugin Replace Active Disable Error',
+      expect.objectContaining({
+        replacedPluginIds: [{ ...uniqueId, etag: 'old' }],
+        error: expect.objectContaining({
+          reason: {
+            en: 'Failed to disable replaced plugins',
+            'zh-CN': '禁用被替换插件失败'
+          },
+          message: 'Failed to disable replaced plugins',
+          error: expect.objectContaining({
+            message: 'Failed to disable replaced plugins',
+            cause: expect.objectContaining({
+              message: 'disable failed'
+            })
+          })
+        })
+      })
+    );
   });
 
   it('logs unregister failures and still completes replacement cleanup', async () => {


### PR DESCRIPTION
## Summary
- include readable validation error details instead of field-only bad request messages
- log failed HTTP request context with safe body snapshots
- enrich usecase error logs with diagnostic context while redacting sensitive/file-like values

## Tests
- pnpm exec tsc --noEmit
- pnpm exec vitest run packages/infrastructure/src/hono/utils/response.test.ts packages/infrastructure/src/hono/utils/request-log.test.ts packages/usecase/src/usecase.test.ts
- git diff --check origin/main...HEAD