### PR TITLE
chore: refresh StepFun model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/StepFun/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/StepFun/index.ts
@@ -18,9 +18,9 @@ const models: ProviderConfigType = {
     {
       type: ModelTypeEnum.llm,
       model: 'step-3.5-flash-2603',
-      maxContext: 64000,
+      maxContext: 256000,
       maxTokens: 8000,
-      quoteMaxToken: 60000,
+      quoteMaxToken: 240000,
       maxTemperature: 2,
       vision: false,
       reasoning: true,
@@ -30,9 +30,9 @@ const models: ProviderConfigType = {
     {
       type: ModelTypeEnum.llm,
       model: 'step-3.5-flash',
-      maxContext: 64000,
+      maxContext: 256000,
       maxTokens: 8000,
-      quoteMaxToken: 60000,
+      quoteMaxToken: 240000,
       maxTemperature: 2,
       vision: false,
       reasoning: true,


### PR DESCRIPTION
## Summary
- update StepFun `step-3.5-flash` and `step-3.5-flash-2603` static preset context windows from 64K to 256K
- align `quoteMaxToken` with the existing 256K StepFun preset pattern

## Evidence
- StepFun model page documents `step-3.5-flash` with 256K context and lists `step-3.5-flash-2603` as the Agent-optimized variant.
- StepFun reasoning model overview documents Step 3.5 Flash context length as 256K.
- StepFun Models API documentation lists both `step-3.5-flash` and `step-3.5-flash-2603` as model IDs.

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider StepFun`
- `./node_modules/.bin/eslint packages/infrastructure/src/static-data/models/provider/StepFun/index.ts`
- `./node_modules/.bin/tsx -e "...staticModelList StepFun import check..."`
- `git diff --check upstream/main...HEAD`

Known existing failures:
- `./node_modules/.bin/tsc --noEmit` fails in `sdk/factory` due Zod v3/v4 type mismatch (`z.GlobalMeta`, `.meta`, `toJSONSchema`).
- `./node_modules/.bin/vitest run` passes 23 files / 159 tests and fails `sdk/factory/src/tool-factory.test.ts:280` with `default.string(...).meta is not a function`; `.env.test` is also missing locally.
