### PR TITLE
feat(connection-gateway): add gateway foundation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,3 +21,53 @@
   - [ ] 获取团队信息
   - [ ] 调用模型
   - [ ] 调用知识库
+
+### Gateway metrics monitor UI
+
+**What:** 将 Connection Gateway `/metrics` 接入现有 debug runtime monitor。
+
+**Why:** Gateway 会暴露 active connections、sessions、in-flight、mailbox lag、slow consumers、Redis latency；接入 UI 后多节点长连接状态更容易排查。
+
+**Context:** PR1 只需要提供稳定 `/metrics` 和 structured logs。UI 接入可以复用现有 runtime monitor 的 requests、latency、queue、crash 展示模式，避免当前 TCP debug 闭环被前端范围拖大。
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Gateway `/metrics` schema 稳定、`apps/debug-runtime-monitor` 数据模型扩展
+
+### Channel WebSocket consumer adapter
+
+**What:** 为 Connection Gateway 增加 channel/WebSocket consumer adapter，用来承载飞书机器人这类渠道长链接。
+
+**Why:** Gateway 已定位为长链接平台能力，plugin debug 只是第一个 consumer；记录渠道 consumer 能防止第一版实现退化成 debug-only。
+
+**Context:** Gateway core 会使用 opaque envelope 和 `ConsumerRegistry`。后续 channel adapter 应作为 consumer 插件接入，复用 session、owner、mailbox、metrics、connection token，不改 Gateway core。
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** `apps/connection-gateway` PR1、`ConsumerRegistry`、connection token、internal API
+
+# P3
+
+### uploadFile true streaming multipart
+
+**What:** 将 `InvokeManager.uploadFile()` 从 bounded buffer 上传升级为 true streaming multipart upload。
+
+**Why:** 本次计划会通过 `MAX_FILE_SIZE` 和 byte counter 保护内存；true streaming multipart 可以进一步降低大文件上传内存峰值。
+
+**Context:** 现有实现会 `Buffer.concat()`。TCP debug v0 可以先靠 20MB 上限安全运行；后续需要确认 FastGPT upload endpoint、Node fetch/FormData、multipart streaming 的兼容性。
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** reverse `uploadFile` v0、FastGPT upload endpoint streaming compatibility 调研
+
+### NATS/JetStream mailbox adapter
+
+**What:** 为 Gateway mailbox 增加 NATS/JetStream adapter，实现和 Redis Streams adapter 同一套 `MailboxPort`。
+
+**Why:** Redis Streams 适合 v0；Gateway 未来承载大量渠道长连接时，可能需要更强的消息语义、消费组治理和跨节点 fanout 能力。
+
+**Context:** Consumer 不直接碰 Redis，Redis 是 Gateway 内部实现。抽出 `MailboxPort` 后，后续加 NATS/JetStream 不需要改 plugin-server 或 channel consumer。
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** Redis Streams adapter 稳定、Gateway mailbox contract tests 成型、生产流量指标

--- a/apps/connection-gateway/Dockerfile
+++ b/apps/connection-gateway/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
-# --------- base -----------
-FROM node:22-alpine AS base
+# --------- build base -----------
+FROM --platform=$BUILDPLATFORM node:22-alpine AS base
 WORKDIR /app
 
 ENV CI=true
@@ -37,7 +37,15 @@ COPY . .
 RUN pnpm --filter @fastgpt-plugin/connection-gateway build
 
 # --------- production dependencies -----------
-FROM base AS prod-deps
+FROM --platform=$TARGETPLATFORM node:22-alpine AS prod-deps
+WORKDIR /app
+
+ENV CI=true
+ENV HUSKY=0
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+RUN corepack enable pnpm
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY apps/connection-gateway/package.json apps/connection-gateway/package.json
@@ -55,7 +63,7 @@ RUN --mount=type=cache,target=/pnpm/store \
       --filter @fastgpt-plugin/connection-gateway...
 
 # --------- runner -----------
-FROM node:22-alpine AS runner
+FROM --platform=$TARGETPLATFORM node:22-alpine AS runner
 WORKDIR /app/apps/connection-gateway
 
 RUN apk add --no-cache \

--- a/apps/connection-gateway/Dockerfile
+++ b/apps/connection-gateway/Dockerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1.7
+
+# --------- base -----------
+FROM node:22-alpine AS base
+WORKDIR /app
+
+ENV CI=true
+ENV HUSKY=0
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+RUN corepack enable pnpm
+
+# --------- deps -----------
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY apps/connection-gateway/package.json apps/connection-gateway/package.json
+COPY packages/domain/package.json packages/domain/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/usecase/package.json packages/usecase/package.json
+COPY packages/interface-adapter/package.json packages/interface-adapter/package.json
+COPY packages/infrastructure/package.json packages/infrastructure/package.json
+COPY sdk/client/package.json sdk/client/package.json
+COPY sdk/factory/package.json sdk/factory/package.json
+
+RUN --mount=type=cache,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && \
+    pnpm install --frozen-lockfile --ignore-scripts \
+      --filter @fastgpt-plugin/connection-gateway...
+
+# --------- builder -----------
+FROM deps AS builder
+
+COPY . .
+
+RUN pnpm --filter @fastgpt-plugin/connection-gateway build
+
+# --------- production dependencies -----------
+FROM base AS prod-deps
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY apps/connection-gateway/package.json apps/connection-gateway/package.json
+COPY packages/domain/package.json packages/domain/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/usecase/package.json packages/usecase/package.json
+COPY packages/interface-adapter/package.json packages/interface-adapter/package.json
+COPY packages/infrastructure/package.json packages/infrastructure/package.json
+COPY sdk/client/package.json sdk/client/package.json
+COPY sdk/factory/package.json sdk/factory/package.json
+
+RUN --mount=type=cache,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && \
+    pnpm install --frozen-lockfile --prod --ignore-scripts \
+      --filter @fastgpt-plugin/connection-gateway...
+
+# --------- runner -----------
+FROM node:22-alpine AS runner
+WORKDIR /app/apps/connection-gateway
+
+RUN apk add --no-cache \
+    curl ca-certificates \
+    && update-ca-certificates \
+    && addgroup -S fastgpt \
+    && adduser -S -G fastgpt fastgpt
+
+COPY --from=prod-deps --chown=fastgpt:fastgpt /app/node_modules /app/node_modules
+COPY --from=prod-deps --chown=fastgpt:fastgpt /app/apps/connection-gateway/node_modules ./node_modules
+COPY --from=prod-deps --chown=fastgpt:fastgpt /app/apps/connection-gateway/package.json ./package.json
+COPY --from=builder --chown=fastgpt:fastgpt /app/apps/connection-gateway/dist ./dist
+
+ENV NODE_ENV=production
+ENV CONNECTION_GATEWAY_PORT=3010
+ENV CONNECTION_GATEWAY_TCP_PORT=3011
+
+EXPOSE 3010 3011
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${CONNECTION_GATEWAY_PORT}/health" >/dev/null || exit 1
+
+USER fastgpt
+CMD ["node", "dist/main.mjs"]

--- a/apps/connection-gateway/main.ts
+++ b/apps/connection-gateway/main.ts
@@ -1,0 +1,98 @@
+import { inspect } from 'node:util';
+
+import { serve, type ServerType } from '@hono/node-server';
+
+import { env } from '@infrastructure/env';
+import { configureLogger, destroyLogger, getLogger, root } from '@infrastructure/logger';
+import { configureMetrics, destroyMetrics } from '@infrastructure/metrics';
+import { configureProxy } from '@infrastructure/utils/proxy';
+import { getErrText } from '@shared/utils/err';
+
+import { makeConnectionGatewayDeps } from './src/deps';
+import { createConnectionGatewayApp } from './src/routes';
+
+await configureLogger();
+await configureMetrics();
+
+const logger = getLogger(root);
+const deps = makeConnectionGatewayDeps();
+const app = createConnectionGatewayApp(deps);
+
+let server: ServerType | null = null;
+let shuttingDown = false;
+
+async function prepare() {
+  configureProxy();
+  await deps.tcpTransport.start();
+}
+
+async function closeServer(): Promise<void> {
+  if (!server) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server?.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function shutdown() {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+
+  void (async () => {
+    let exitCode = 0;
+
+    try {
+      await deps.tcpTransport.stop();
+      await closeServer();
+      await deps.redisClient.disconnect();
+      await destroyMetrics();
+    } catch (error) {
+      exitCode = 1;
+      logger.error('Failed to shutdown connection gateway cleanly', { error });
+    } finally {
+      await destroyLogger();
+      process.exit(exitCode);
+    }
+  })();
+}
+
+async function main() {
+  try {
+    await prepare();
+  } catch (error) {
+    const errorMessage = getErrText(error, 'Unknown connection gateway startup error');
+
+    console.error(inspect(error, { depth: null }));
+    console.info(`Failed startup connection gateway: ${errorMessage}`);
+    shutdown();
+    return;
+  }
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  server = serve(
+    {
+      fetch: app.fetch,
+      port: env.CONNECTION_GATEWAY_PORT
+    },
+    (info) => {
+      logger.info(`Connection Gateway HTTP server is listening at http://0.0.0.0:${info.port}`);
+      logger.info(`Connection Gateway TCP server is listening at tcp://0.0.0.0:${env.CONNECTION_GATEWAY_TCP_PORT}`);
+    }
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/apps/connection-gateway/package.json
+++ b/apps/connection-gateway/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@fastgpt-plugin/connection-gateway",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch --env-file-if-exists=.env.local main.ts",
+    "build": "tsdown main.ts"
+  },
+  "dependencies": {
+    "@fastgpt-plugin/domain": "workspace:*",
+    "@fastgpt-plugin/infrastructure": "workspace:*",
+    "@fastgpt-plugin/interface-adapter": "workspace:*",
+    "@fastgpt-plugin/shared": "workspace:*",
+    "@hono/node-server": "^1.19.9",
+    "hono": "^4.12.21",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "tsdown": "catalog:",
+    "tsx": "^4.19.2",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/connection-gateway/src/deps.ts
+++ b/apps/connection-gateway/src/deps.ts
@@ -1,0 +1,81 @@
+import { ConnectionGatewayResourceLimitsSchema } from '@domain/value-objects/connection-gateway.vo';
+import { HmacConnectionGatewayToken } from '@infrastructure/connection-gateway/token';
+import { RedisConnectionGatewayMailbox } from '@infrastructure/connection-gateway/mailbox';
+import { InMemoryConnectionGatewayMetrics } from '@infrastructure/connection-gateway/metrics';
+import { ConnectionGatewayResourceLimiter } from '@infrastructure/connection-gateway/resource-limiter';
+import { ConnectionGatewayService } from '@infrastructure/connection-gateway/service';
+import { RedisConnectionGatewaySessionRegistry } from '@infrastructure/connection-gateway/session-registry';
+import { TcpConnectionGatewayTransport } from '@infrastructure/connection-gateway/transports/tcp-transport';
+import { env } from '@infrastructure/env';
+import { getLogger, root } from '@infrastructure/logger';
+import { getServiceInstanceId } from '@infrastructure/metrics';
+import { RedisClient } from '@infrastructure/redis/redis-client';
+
+export function makeConnectionGatewayDeps() {
+  const logger = getLogger(root);
+  const redisClient = RedisClient.getInstance();
+  const nodeId = env.CONNECTION_GATEWAY_NODE_ID ?? getServiceInstanceId();
+  const limits = ConnectionGatewayResourceLimitsSchema.parse({
+    maxConnections: env.CONNECTION_GATEWAY_MAX_CONNECTIONS,
+    maxSessionsPerSubject: env.CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT,
+    maxInFlightPerSession: env.CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION,
+    maxEnvelopeBytes: env.CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES,
+    slowConsumerBufferBytes: env.CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES
+  });
+  const metrics = new InMemoryConnectionGatewayMetrics(nodeId, limits);
+  const limiter = new ConnectionGatewayResourceLimiter(limits);
+  const tokenVerifier = new HmacConnectionGatewayToken(env.JWT_SECRET);
+  const sessionRegistry = new RedisConnectionGatewaySessionRegistry(
+    redisClient.getClient,
+    env.CONNECTION_GATEWAY_SESSION_TTL_MS
+  );
+  const mailbox = new RedisConnectionGatewayMailbox(redisClient.getClient, {
+    maxLen: env.CONNECTION_GATEWAY_MAILBOX_MAXLEN,
+    metrics
+  });
+  const service = new ConnectionGatewayService({
+    tokenVerifier,
+    sessionRegistry,
+    mailbox,
+    metrics,
+    limiter,
+    options: {
+      nodeId,
+      sessionTtlMs: env.CONNECTION_GATEWAY_SESSION_TTL_MS,
+      ownerLeaseTtlMs: env.CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS,
+      mailboxMaxLen: env.CONNECTION_GATEWAY_MAILBOX_MAXLEN
+    }
+  });
+  const tcpTransport = new TcpConnectionGatewayTransport({
+    port: env.CONNECTION_GATEWAY_TCP_PORT,
+    maxFrameBytes: env.CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES,
+    limiter,
+    handlers: {
+      onConnection: () => metrics.recordConnectionOpened(),
+      onClose: () => metrics.recordConnectionClosed(),
+      onEnvelope: async (_connection, envelope) => {
+        await service.publishRequest({
+          sessionId: envelope.sessionId,
+          envelope
+        });
+      },
+      onError: (connection, error) => {
+        logger.warn('Connection Gateway TCP transport error', {
+          connectionId: connection?.id,
+          remoteAddress: connection?.remoteAddress,
+          error
+        });
+      }
+    }
+  });
+
+  return {
+    redisClient,
+    service,
+    tcpTransport,
+    metrics,
+    limiter
+  };
+}
+
+export type ConnectionGatewayDeps = ReturnType<typeof makeConnectionGatewayDeps>;

--- a/apps/connection-gateway/src/routes.ts
+++ b/apps/connection-gateway/src/routes.ts
@@ -1,0 +1,247 @@
+import { ErrorResponseDTOSchema } from '@interface-adapter/contracts/dto/common.dto';
+import {
+  ConnectionGatewayCreateSessionRequestDTOSchema,
+  ConnectionGatewayCreateSessionResponseDTOSchema,
+  ConnectionGatewayMetricsDTOSchema,
+  ConnectionGatewayRequestAcceptedDTOSchema,
+  ConnectionGatewayRequestDTOSchema,
+  ConnectionGatewaySessionStatusViewDTOSchema
+} from '@interface-adapter/contracts/dto/connection-gateway.dto';
+import { cors } from 'hono/cors';
+import { requestId } from 'hono/request-id';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+import z from 'zod';
+
+import { RegisteredError } from '@domain/value-objects/error.vo';
+import { bearerHonoAuthMiddleware } from '@infrastructure/hono/middleware/auth';
+import { loggerHonoMiddleware } from '@infrastructure/hono/middleware/logger';
+import { createOpenAPIHono, createRoute, R } from '@infrastructure/hono/utils/response';
+
+import type { ConnectionGatewayDeps } from './deps';
+
+export function createConnectionGatewayApp(deps: Pick<ConnectionGatewayDeps, 'service'>) {
+  const app = createOpenAPIHono();
+
+  app.use(
+    '*',
+    cors({
+      origin: '*',
+      allowHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token'],
+      allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      credentials: true
+    })
+  );
+  app.use('*', requestId());
+  app.use('*', loggerHonoMiddleware);
+  app.use('/metrics', bearerHonoAuthMiddleware);
+  app.use('/internal/*', bearerHonoAuthMiddleware);
+
+  app.doc31('/openapi.json', {
+    openapi: '3.1.0',
+    info: {
+      title: 'FastGPT Connection Gateway API',
+      version: '1.0.0'
+    },
+    security: [{ bearerAuth: [] }]
+  });
+
+  app.openAPIRegistry.registerComponent('securitySchemes', 'bearerAuth', {
+    type: 'http',
+    scheme: 'bearer'
+  });
+
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/health',
+      summary: 'Health check',
+      tags: ['connection-gateway'],
+      responses: {
+        200: {
+          description: 'OK',
+          content: {
+            'application/json': {
+              schema: z.object({
+                data: z.object({
+                  status: z.string(),
+                  timestamp: z.string()
+                })
+              })
+            }
+          }
+        }
+      }
+    }),
+    (c) => R.success(c, { status: 'ok', timestamp: new Date().toISOString() })
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/metrics',
+      summary: 'Gateway metrics',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: jsonResponse(ConnectionGatewayMetricsDTOSchema)
+      }
+    }),
+    (c) => R.success(c, deps.service.metrics())
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'post',
+      path: '/internal/sessions',
+      summary: 'Create a gateway session',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      request: jsonRequest(ConnectionGatewayCreateSessionRequestDTOSchema),
+      responses: {
+        200: jsonResponse(ConnectionGatewayCreateSessionResponseDTOSchema),
+        400: errorResponse(),
+        401: errorResponse(),
+        429: errorResponse()
+      }
+    }),
+    async (c) => {
+      try {
+        const body = ConnectionGatewayCreateSessionRequestDTOSchema.parse(c.req.valid('json'));
+        const session = await deps.service.createSession(body);
+
+        return R.success(c, { session });
+      } catch (error) {
+        return R.fail(c, statusFromError(error), normalizeError(error));
+      }
+    }
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'get',
+      path: '/internal/sessions/:sessionId/status',
+      summary: 'Get gateway session status',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: jsonResponse(ConnectionGatewaySessionStatusViewDTOSchema),
+        404: errorResponse()
+      }
+    }),
+    async (c) => {
+      const status = await deps.service.getStatus(requiredParam(c.req.param('sessionId')));
+      if (!status.session) {
+        return R.fail(c, 404, 'Gateway session not found');
+      }
+
+      return R.success(c, status);
+    }
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'post',
+      path: '/internal/sessions/:sessionId/requests',
+      summary: 'Publish a request envelope to a session mailbox',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      request: jsonRequest(ConnectionGatewayRequestDTOSchema),
+      responses: {
+        202: jsonResponse(ConnectionGatewayRequestAcceptedDTOSchema),
+        400: errorResponse(),
+        403: errorResponse(),
+        404: errorResponse(),
+        409: errorResponse(),
+        413: errorResponse(),
+        429: errorResponse()
+      }
+    }),
+    async (c) => {
+      try {
+        const body = c.req.valid('json');
+        const parsed = ConnectionGatewayRequestDTOSchema.parse(body);
+        const result = await deps.service.publishRequest({
+          sessionId: requiredParam(c.req.param('sessionId')),
+          envelope: parsed.envelope
+        });
+
+        return c.json({ data: result }, 202);
+      } catch (error) {
+        return R.fail(c, statusFromError(error), normalizeError(error));
+      }
+    }
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'delete',
+      path: '/internal/sessions/:sessionId',
+      summary: 'Delete a gateway session',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: jsonResponse(z.object({ deleted: z.boolean() }))
+      }
+    }),
+    async (c) => {
+      await deps.service.deleteSession(requiredParam(c.req.param('sessionId')));
+      return R.success(c, { deleted: true });
+    }
+  );
+
+  return app;
+}
+
+function jsonRequest(schema: z.ZodType) {
+  return {
+    body: {
+      content: {
+        'application/json': {
+          schema
+        }
+      }
+    }
+  };
+}
+
+function jsonResponse(schema: z.ZodType) {
+  return {
+    description: 'JSON response',
+    content: {
+      'application/json': {
+        schema: z.object({ data: schema })
+      }
+    }
+  };
+}
+
+function errorResponse() {
+  return {
+    description: 'Error response',
+    content: {
+      'application/json': {
+        schema: z.object({ error: ErrorResponseDTOSchema })
+      }
+    }
+  };
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function statusFromError(error: unknown): ContentfulStatusCode {
+  if (error instanceof RegisteredError) {
+    return error.httpStatus as ContentfulStatusCode;
+  }
+
+  return 500;
+}
+
+function requiredParam(value: string | undefined): string {
+  if (!value) {
+    throw new Error('Missing required route param');
+  }
+
+  return value;
+}

--- a/apps/connection-gateway/tsconfig.json
+++ b/apps/connection-gateway/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "build:sdk-client": "pnpm --filter @fastgpt-plugin/sdk-client build",
     "build:sdk-factory": "pnpm --filter @fastgpt-plugin/sdk-factory build",
     "build:server": "pnpm --filter @fastgpt-plugin/server build",
+    "build:connection-gateway": "pnpm --filter @fastgpt-plugin/connection-gateway build",
     "build:cli": "pnpm --filter @fastgpt-plugin/cli build",
     "build:debug-runtime-monitor": "pnpm --filter @fastgpt-plugin/debug-runtime-monitor build",
     "dev:cli": "pnpm --filter @fastgpt-plugin/cli dev",
+    "dev:connection-gateway": "pnpm --filter @fastgpt-plugin/connection-gateway dev",
     "dev:server": "pnpm --filter @fastgpt-plugin/server dev",
     "dev:debug-runtime-monitor": "pnpm --filter @fastgpt-plugin/debug-runtime-monitor dev"
   },

--- a/packages/domain/src/ports/connection-gateway/connection-token.port.ts
+++ b/packages/domain/src/ports/connection-gateway/connection-token.port.ts
@@ -1,0 +1,20 @@
+import type {
+  ConnectionGatewayCapability,
+  ConnectionGatewayTokenClaims,
+  ConnectionGatewayTransport
+} from '@domain/value-objects/connection-gateway.vo';
+
+export type VerifyConnectionTokenInput = {
+  token: string;
+  expectedTransport?: ConnectionGatewayTransport;
+  requiredCapability?: ConnectionGatewayCapability;
+  now?: number;
+};
+
+export interface ConnectionGatewayTokenVerifierPort {
+  verify(input: VerifyConnectionTokenInput): Promise<ConnectionGatewayTokenClaims>;
+}
+
+export interface ConnectionGatewayTokenSignerPort {
+  sign(claims: ConnectionGatewayTokenClaims): Promise<string>;
+}

--- a/packages/domain/src/ports/connection-gateway/consumer-registry.port.ts
+++ b/packages/domain/src/ports/connection-gateway/consumer-registry.port.ts
@@ -1,0 +1,19 @@
+import type {
+  ConnectionGatewayConsumerType,
+  ConnectionGatewayEnvelope
+} from '@domain/value-objects/connection-gateway.vo';
+
+export type ConnectionGatewayConsumerHandlerResult = {
+  envelope?: ConnectionGatewayEnvelope;
+  stream?: AsyncIterable<ConnectionGatewayEnvelope>;
+};
+
+export type ConnectionGatewayConsumerHandler = (
+  envelope: ConnectionGatewayEnvelope
+) => Promise<ConnectionGatewayConsumerHandlerResult>;
+
+export interface ConnectionGatewayConsumerRegistryPort {
+  register(consumerType: ConnectionGatewayConsumerType, handler: ConnectionGatewayConsumerHandler): void;
+  get(consumerType: ConnectionGatewayConsumerType): ConnectionGatewayConsumerHandler | null;
+  has(consumerType: ConnectionGatewayConsumerType): boolean;
+}

--- a/packages/domain/src/ports/connection-gateway/mailbox.port.ts
+++ b/packages/domain/src/ports/connection-gateway/mailbox.port.ts
@@ -1,0 +1,22 @@
+import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
+
+export type ConnectionGatewayMailboxMessage = {
+  id: string;
+  envelope: ConnectionGatewayEnvelope;
+};
+
+export type ConnectionGatewayMailboxReadInput = {
+  sessionId: string;
+  afterId?: string;
+  blockMs?: number;
+  count?: number;
+};
+
+export interface ConnectionGatewayMailboxPort {
+  publish(sessionId: string, envelope: ConnectionGatewayEnvelope): Promise<string>;
+  read(input: ConnectionGatewayMailboxReadInput): Promise<ConnectionGatewayMailboxMessage[]>;
+  ack(sessionId: string, messageIds: string[]): Promise<void>;
+  trim(sessionId: string, maxLen: number): Promise<void>;
+  expire(sessionId: string, ttlMs: number): Promise<void>;
+  lag(sessionId: string): Promise<number>;
+}

--- a/packages/domain/src/ports/connection-gateway/metrics.port.ts
+++ b/packages/domain/src/ports/connection-gateway/metrics.port.ts
@@ -1,0 +1,16 @@
+import type { ConnectionGatewayMetrics } from '@domain/value-objects/connection-gateway.vo';
+
+export interface ConnectionGatewayMetricsPort {
+  snapshot(): ConnectionGatewayMetrics;
+  recordConnectionOpened(): void;
+  recordConnectionClosed(): void;
+  recordSessionOpened(): void;
+  recordSessionClosed(): void;
+  recordRequestStarted(sessionId: string): void;
+  recordRequestCompleted(sessionId: string): void;
+  recordStreamBufferBytes(bytes: number): void;
+  recordSlowConsumer(): void;
+  recordOwnerLeaseExpiry(): void;
+  recordMailboxLag(lag: number): void;
+  recordRedisRoundTrip(durationMs: number): void;
+}

--- a/packages/domain/src/ports/connection-gateway/session-registry.port.ts
+++ b/packages/domain/src/ports/connection-gateway/session-registry.port.ts
@@ -1,0 +1,35 @@
+import type {
+  ConnectionGatewaySession,
+  ConnectionGatewaySessionStatus
+} from '@domain/value-objects/connection-gateway.vo';
+
+export type CreateConnectionGatewaySessionInput = Omit<
+  ConnectionGatewaySession,
+  'generation' | 'status' | 'connectedAt' | 'lastSeenAt'
+> & {
+  generation?: number;
+  status?: ConnectionGatewaySessionStatus;
+  now?: number;
+};
+
+export type RenewConnectionGatewayOwnerLeaseInput = {
+  sessionId: string;
+  ownerNodeId: string;
+  expiresAt: number;
+  now?: number;
+};
+
+export interface ConnectionGatewaySessionRegistryPort {
+  create(input: CreateConnectionGatewaySessionInput): Promise<ConnectionGatewaySession>;
+  get(sessionId: string): Promise<ConnectionGatewaySession | null>;
+  listBySubject(subject: string): Promise<ConnectionGatewaySession[]>;
+  renewOwnerLease(input: RenewConnectionGatewayOwnerLeaseInput): Promise<boolean>;
+  updateStatus(input: {
+    sessionId: string;
+    ownerNodeId: string;
+    status: ConnectionGatewaySessionStatus;
+    now?: number;
+  }): Promise<boolean>;
+  remove(sessionId: string): Promise<void>;
+  countActive(): Promise<number>;
+}

--- a/packages/domain/src/value-objects/connection-gateway.vo.ts
+++ b/packages/domain/src/value-objects/connection-gateway.vo.ts
@@ -1,0 +1,131 @@
+import z from 'zod';
+
+export const ConnectionGatewayConsumerTypeSchema = z.string().min(1).max(64);
+export type ConnectionGatewayConsumerType = z.infer<typeof ConnectionGatewayConsumerTypeSchema>;
+
+export const ConnectionGatewayTransportSchema = z.enum(['tcp', 'websocket']);
+export type ConnectionGatewayTransport = z.infer<typeof ConnectionGatewayTransportSchema>;
+
+export const ConnectionGatewayCapabilitySchema = z.string().min(1).max(64);
+export type ConnectionGatewayCapability = z.infer<typeof ConnectionGatewayCapabilitySchema>;
+
+export const ConnectionGatewaySessionScopeSchema = z.object({
+  userId: z.string().min(1),
+  teamId: z.string().min(1).optional(),
+  source: z.string().min(1).optional()
+});
+export type ConnectionGatewaySessionScope = z.infer<typeof ConnectionGatewaySessionScopeSchema>;
+
+export const ConnectionGatewayTokenClaimsSchema = z.object({
+  consumerType: ConnectionGatewayConsumerTypeSchema,
+  subject: z.string().min(1),
+  sessionScope: ConnectionGatewaySessionScopeSchema,
+  transport: ConnectionGatewayTransportSchema,
+  capabilities: z.array(ConnectionGatewayCapabilitySchema).default([]),
+  expiresAt: z.number().int().positive(),
+  issuedAt: z.number().int().positive().optional(),
+  nonce: z.string().min(1).optional()
+});
+export type ConnectionGatewayTokenClaims = z.infer<typeof ConnectionGatewayTokenClaimsSchema>;
+
+export const ConnectionGatewayEnvelopeSchema = z.object({
+  protocol: z.literal('connection-gateway.v1'),
+  sessionId: z.string().min(1),
+  generation: z.number().int().nonnegative(),
+  requestId: z.string().min(1).optional(),
+  type: z.enum(['request', 'response', 'event', 'stream']),
+  consumerType: ConnectionGatewayConsumerTypeSchema,
+  capability: ConnectionGatewayCapabilitySchema.optional(),
+  traceId: z.string().optional(),
+  payload: z.unknown().optional(),
+  createdAt: z.number().int().positive()
+});
+export type ConnectionGatewayEnvelope = z.infer<typeof ConnectionGatewayEnvelopeSchema>;
+
+export const ConnectionGatewaySessionStatusSchema = z.enum([
+  'connecting',
+  'connected',
+  'draining',
+  'closed'
+]);
+export type ConnectionGatewaySessionStatus = z.infer<typeof ConnectionGatewaySessionStatusSchema>;
+
+export const ConnectionGatewaySessionSchema = z.object({
+  id: z.string().min(1),
+  consumerType: ConnectionGatewayConsumerTypeSchema,
+  subject: z.string().min(1),
+  sessionScope: ConnectionGatewaySessionScopeSchema,
+  transport: ConnectionGatewayTransportSchema,
+  capabilities: z.array(ConnectionGatewayCapabilitySchema),
+  generation: z.number().int().nonnegative(),
+  ownerNodeId: z.string().min(1),
+  status: ConnectionGatewaySessionStatusSchema,
+  connectedAt: z.number().int().positive(),
+  lastSeenAt: z.number().int().positive(),
+  expiresAt: z.number().int().positive()
+});
+export type ConnectionGatewaySession = z.infer<typeof ConnectionGatewaySessionSchema>;
+
+export const ConnectionGatewaySessionStatusViewSchema = z.object({
+  session: ConnectionGatewaySessionSchema.nullable(),
+  ownerAlive: z.boolean(),
+  mailboxLag: z.number().int().nonnegative(),
+  logs: z.array(
+    z.object({
+      ts: z.number().int().positive(),
+      level: z.enum(['debug', 'info', 'warn', 'error']),
+      message: z.string(),
+      data: z.record(z.string(), z.unknown()).optional()
+    })
+  )
+});
+export type ConnectionGatewaySessionStatusView = z.infer<
+  typeof ConnectionGatewaySessionStatusViewSchema
+>;
+
+export const ConnectionGatewayMetricsSchema = z.object({
+  nodeId: z.string(),
+  activeConnections: z.number().int().nonnegative(),
+  activeSessions: z.number().int().nonnegative(),
+  inFlightRequests: z.number().int().nonnegative(),
+  streamBufferBytes: z.number().int().nonnegative(),
+  slowConsumers: z.number().int().nonnegative(),
+  ownerLeaseExpiries: z.number().int().nonnegative(),
+  mailbox: z.object({
+    lag: z.number().int().nonnegative(),
+    redisRoundTripMs: z.number().nonnegative()
+  }),
+  limits: z.object({
+    maxConnections: z.number().int().positive(),
+    maxSessionsPerSubject: z.number().int().positive(),
+    maxInFlightPerSession: z.number().int().positive(),
+    maxEnvelopeBytes: z.number().int().positive()
+  })
+});
+export type ConnectionGatewayMetrics = z.infer<typeof ConnectionGatewayMetricsSchema>;
+
+export const ConnectionGatewayResourceLimitsSchema = z.object({
+  maxConnections: z.number().int().positive(),
+  maxSessionsPerSubject: z.number().int().positive(),
+  maxInFlightPerSession: z.number().int().positive(),
+  maxEnvelopeBytes: z.number().int().positive(),
+  slowConsumerBufferBytes: z.number().int().positive()
+});
+export type ConnectionGatewayResourceLimits = z.infer<
+  typeof ConnectionGatewayResourceLimitsSchema
+>;
+
+export const ConnectionGatewayErrorCode = {
+  invalidToken: 'CONNECTION_GATEWAY_INVALID_TOKEN',
+  tokenExpired: 'CONNECTION_GATEWAY_TOKEN_EXPIRED',
+  transportMismatch: 'CONNECTION_GATEWAY_TRANSPORT_MISMATCH',
+  capabilityDenied: 'CONNECTION_GATEWAY_CAPABILITY_DENIED',
+  staleGeneration: 'CONNECTION_GATEWAY_STALE_GENERATION',
+  sessionNotFound: 'CONNECTION_GATEWAY_SESSION_NOT_FOUND',
+  sessionOwnerExpired: 'CONNECTION_GATEWAY_SESSION_OWNER_EXPIRED',
+  resourceLimitExceeded: 'CONNECTION_GATEWAY_RESOURCE_LIMIT_EXCEEDED',
+  envelopeTooLarge: 'CONNECTION_GATEWAY_ENVELOPE_TOO_LARGE'
+} as const;
+
+export type ConnectionGatewayErrorCode =
+  (typeof ConnectionGatewayErrorCode)[keyof typeof ConnectionGatewayErrorCode];

--- a/packages/infrastructure/src/connection-gateway/consumer-registry.ts
+++ b/packages/infrastructure/src/connection-gateway/consumer-registry.ts
@@ -1,0 +1,26 @@
+import type {
+  ConnectionGatewayConsumerHandler,
+  ConnectionGatewayConsumerRegistryPort
+} from '@domain/ports/connection-gateway/consumer-registry.port';
+import type { ConnectionGatewayConsumerType } from '@domain/value-objects/connection-gateway.vo';
+
+export class InMemoryConnectionGatewayConsumerRegistry
+  implements ConnectionGatewayConsumerRegistryPort
+{
+  private readonly handlers = new Map<ConnectionGatewayConsumerType, ConnectionGatewayConsumerHandler>();
+
+  register(
+    consumerType: ConnectionGatewayConsumerType,
+    handler: ConnectionGatewayConsumerHandler
+  ): void {
+    this.handlers.set(consumerType, handler);
+  }
+
+  get(consumerType: ConnectionGatewayConsumerType): ConnectionGatewayConsumerHandler | null {
+    return this.handlers.get(consumerType) ?? null;
+  }
+
+  has(consumerType: ConnectionGatewayConsumerType): boolean {
+    return this.handlers.has(consumerType);
+  }
+}

--- a/packages/infrastructure/src/connection-gateway/mailbox.test.ts
+++ b/packages/infrastructure/src/connection-gateway/mailbox.test.ts
@@ -1,0 +1,43 @@
+import '@infrastructure/errors/error.registry';
+
+import { describe, expect, it } from 'vitest';
+
+import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
+
+import { InMemoryConnectionGatewayMailbox } from './mailbox';
+
+function makeEnvelope(id: string): ConnectionGatewayEnvelope {
+  return {
+    protocol: 'connection-gateway.v1',
+    sessionId: 'session-a',
+    generation: 0,
+    requestId: id,
+    type: 'request',
+    consumerType: 'plugin-debug',
+    capability: 'invoke',
+    createdAt: Date.now(),
+    payload: { id }
+  };
+}
+
+describe('InMemoryConnectionGatewayMailbox', () => {
+  it('publishes, reads, acknowledges, and trims envelopes in order', async () => {
+    const mailbox = new InMemoryConnectionGatewayMailbox();
+    const first = await mailbox.publish('session-a', makeEnvelope('first'));
+    const second = await mailbox.publish('session-a', makeEnvelope('second'));
+
+    await expect(mailbox.read({ sessionId: 'session-a', count: 10 })).resolves.toEqual([
+      expect.objectContaining({ id: first }),
+      expect.objectContaining({ id: second })
+    ]);
+
+    await mailbox.ack('session-a', [first]);
+    await expect(mailbox.read({ sessionId: 'session-a', count: 10 })).resolves.toEqual([
+      expect.objectContaining({ id: second })
+    ]);
+
+    await mailbox.publish('session-a', makeEnvelope('third'));
+    await mailbox.trim('session-a', 1);
+    await expect(mailbox.lag('session-a')).resolves.toBe(1);
+  });
+});

--- a/packages/infrastructure/src/connection-gateway/mailbox.ts
+++ b/packages/infrastructure/src/connection-gateway/mailbox.ts
@@ -1,0 +1,179 @@
+import type Redis from 'ioredis';
+
+import type {
+  ConnectionGatewayMailboxMessage,
+  ConnectionGatewayMailboxPort,
+  ConnectionGatewayMailboxReadInput
+} from '@domain/ports/connection-gateway/mailbox.port';
+import {
+  type ConnectionGatewayEnvelope,
+  ConnectionGatewayEnvelopeSchema
+} from '@domain/value-objects/connection-gateway.vo';
+
+import type { InMemoryConnectionGatewayMetrics } from './metrics';
+
+const MAILBOX_KEY_PREFIX = 'connection-gateway:mailbox';
+
+type RedisStreamEntry = [string, string[]];
+type RedisStreamResponse = Array<[string, RedisStreamEntry[]]> | null;
+
+export class InMemoryConnectionGatewayMailbox implements ConnectionGatewayMailboxPort {
+  private sequence = 0;
+  private readonly streams = new Map<string, ConnectionGatewayMailboxMessage[]>();
+
+  async publish(sessionId: string, envelope: ConnectionGatewayEnvelope): Promise<string> {
+    const id = `${Date.now()}-${++this.sequence}`;
+    const stream = this.getStream(sessionId);
+    stream.push({ id, envelope });
+    return id;
+  }
+
+  async read(input: ConnectionGatewayMailboxReadInput): Promise<ConnectionGatewayMailboxMessage[]> {
+    const stream = this.getStream(input.sessionId);
+    const startIndex = input.afterId
+      ? stream.findIndex((message) => message.id === input.afterId) + 1
+      : 0;
+    const count = input.count ?? stream.length;
+
+    return stream.slice(Math.max(0, startIndex), Math.max(0, startIndex) + count);
+  }
+
+  async ack(sessionId: string, messageIds: string[]): Promise<void> {
+    const messageIdSet = new Set(messageIds);
+    const stream = this.getStream(sessionId).filter((message) => !messageIdSet.has(message.id));
+    this.streams.set(sessionId, stream);
+  }
+
+  async trim(sessionId: string, maxLen: number): Promise<void> {
+    const stream = this.getStream(sessionId);
+    if (stream.length <= maxLen) {
+      return;
+    }
+
+    this.streams.set(sessionId, stream.slice(stream.length - maxLen));
+  }
+
+  async expire(sessionId: string, _ttlMs: number): Promise<void> {
+    if (!this.streams.has(sessionId)) {
+      return;
+    }
+  }
+
+  async lag(sessionId: string): Promise<number> {
+    return this.getStream(sessionId).length;
+  }
+
+  private getStream(sessionId: string): ConnectionGatewayMailboxMessage[] {
+    const stream = this.streams.get(sessionId);
+    if (stream) {
+      return stream;
+    }
+
+    const next: ConnectionGatewayMailboxMessage[] = [];
+    this.streams.set(sessionId, next);
+    return next;
+  }
+}
+
+export class RedisConnectionGatewayMailbox implements ConnectionGatewayMailboxPort {
+  constructor(
+    private readonly redis: Redis,
+    private readonly options: {
+      maxLen: number;
+      metrics?: InMemoryConnectionGatewayMetrics;
+    }
+  ) {}
+
+  async publish(sessionId: string, envelope: ConnectionGatewayEnvelope): Promise<string> {
+    return this.recordRedisRoundTrip(async () => {
+      const messageId = await this.redis.xadd(
+        this.key(sessionId),
+        'MAXLEN',
+        '~',
+        this.options.maxLen,
+        '*',
+        'envelope',
+        JSON.stringify(envelope)
+      );
+
+      if (!messageId) {
+        throw new Error('Redis XADD did not return a message id');
+      }
+
+      return messageId;
+    });
+  }
+
+  async read(input: ConnectionGatewayMailboxReadInput): Promise<ConnectionGatewayMailboxMessage[]> {
+    return this.recordRedisRoundTrip(async () => {
+      const result = await this.xread(
+        'BLOCK',
+        input.blockMs ?? 0,
+        'COUNT',
+        input.count ?? 10,
+        'STREAMS',
+        this.key(input.sessionId),
+        input.afterId ?? '0-0'
+      );
+
+      if (!result?.length) {
+        return [];
+      }
+
+      return result.flatMap(([, entries]) =>
+        entries.map(([id, values]) => {
+          const envelopeIndex = values.findIndex((value) => value === 'envelope');
+          const raw = envelopeIndex >= 0 ? values[envelopeIndex + 1] : undefined;
+
+          return {
+            id,
+            envelope: ConnectionGatewayEnvelopeSchema.parse(JSON.parse(raw ?? '{}'))
+          };
+        })
+      );
+    });
+  }
+
+  async ack(sessionId: string, messageIds: string[]): Promise<void> {
+    if (!messageIds.length) {
+      return;
+    }
+
+    await this.recordRedisRoundTrip(async () => {
+      await this.redis.xdel(this.key(sessionId), ...messageIds);
+    });
+  }
+
+  async trim(sessionId: string, maxLen: number): Promise<void> {
+    await this.recordRedisRoundTrip(async () => {
+      await this.redis.xtrim(this.key(sessionId), 'MAXLEN', '~', maxLen);
+    });
+  }
+
+  async expire(sessionId: string, ttlMs: number): Promise<void> {
+    await this.recordRedisRoundTrip(async () => {
+      await this.redis.pexpire(this.key(sessionId), ttlMs);
+    });
+  }
+
+  async lag(sessionId: string): Promise<number> {
+    return this.recordRedisRoundTrip(async () => this.redis.xlen(this.key(sessionId)));
+  }
+
+  private key(sessionId: string): string {
+    return `${MAILBOX_KEY_PREFIX}:${sessionId}`;
+  }
+
+  private async xread(...args: Array<string | number>): Promise<RedisStreamResponse> {
+    return this.redis.call('XREAD', ...args) as Promise<RedisStreamResponse>;
+  }
+
+  private async recordRedisRoundTrip<T>(fn: () => Promise<T>): Promise<T> {
+    const startedAt = Date.now();
+    try {
+      return await fn();
+    } finally {
+      this.options.metrics?.recordRedisRoundTrip(Date.now() - startedAt);
+    }
+  }
+}

--- a/packages/infrastructure/src/connection-gateway/metrics.ts
+++ b/packages/infrastructure/src/connection-gateway/metrics.ts
@@ -1,0 +1,87 @@
+import type { ConnectionGatewayMetricsPort } from '@domain/ports/connection-gateway/metrics.port';
+import type {
+  ConnectionGatewayMetrics,
+  ConnectionGatewayResourceLimits
+} from '@domain/value-objects/connection-gateway.vo';
+
+export class InMemoryConnectionGatewayMetrics implements ConnectionGatewayMetricsPort {
+  private activeConnections = 0;
+  private activeSessions = 0;
+  private inFlightRequests = 0;
+  private streamBufferBytes = 0;
+  private slowConsumers = 0;
+  private ownerLeaseExpiries = 0;
+  private mailboxLag = 0;
+  private redisRoundTripMs = 0;
+
+  constructor(
+    private readonly nodeId: string,
+    private readonly limits: ConnectionGatewayResourceLimits
+  ) {}
+
+  snapshot(): ConnectionGatewayMetrics {
+    return {
+      nodeId: this.nodeId,
+      activeConnections: this.activeConnections,
+      activeSessions: this.activeSessions,
+      inFlightRequests: this.inFlightRequests,
+      streamBufferBytes: this.streamBufferBytes,
+      slowConsumers: this.slowConsumers,
+      ownerLeaseExpiries: this.ownerLeaseExpiries,
+      mailbox: {
+        lag: this.mailboxLag,
+        redisRoundTripMs: this.redisRoundTripMs
+      },
+      limits: {
+        maxConnections: this.limits.maxConnections,
+        maxSessionsPerSubject: this.limits.maxSessionsPerSubject,
+        maxInFlightPerSession: this.limits.maxInFlightPerSession,
+        maxEnvelopeBytes: this.limits.maxEnvelopeBytes
+      }
+    };
+  }
+
+  recordConnectionOpened(): void {
+    this.activeConnections += 1;
+  }
+
+  recordConnectionClosed(): void {
+    this.activeConnections = Math.max(0, this.activeConnections - 1);
+  }
+
+  recordSessionOpened(): void {
+    this.activeSessions += 1;
+  }
+
+  recordSessionClosed(): void {
+    this.activeSessions = Math.max(0, this.activeSessions - 1);
+  }
+
+  recordRequestStarted(): void {
+    this.inFlightRequests += 1;
+  }
+
+  recordRequestCompleted(): void {
+    this.inFlightRequests = Math.max(0, this.inFlightRequests - 1);
+  }
+
+  recordStreamBufferBytes(bytes: number): void {
+    this.streamBufferBytes = Math.max(0, bytes);
+  }
+
+  recordSlowConsumer(): void {
+    this.slowConsumers += 1;
+  }
+
+  recordOwnerLeaseExpiry(): void {
+    this.ownerLeaseExpiries += 1;
+  }
+
+  recordMailboxLag(lag: number): void {
+    this.mailboxLag = Math.max(0, lag);
+  }
+
+  recordRedisRoundTrip(durationMs: number): void {
+    this.redisRoundTripMs = Math.max(0, durationMs);
+  }
+}

--- a/packages/infrastructure/src/connection-gateway/resource-limiter.ts
+++ b/packages/infrastructure/src/connection-gateway/resource-limiter.ts
@@ -1,0 +1,88 @@
+import type { ConnectionGatewayResourceLimits } from '@domain/value-objects/connection-gateway.vo';
+import { createError } from '@domain/value-objects/error.vo';
+
+import { ErrorCode } from '../errors/error.registry';
+
+export class ConnectionGatewayResourceLimiter {
+  private activeConnections = 0;
+  private readonly inFlightBySession = new Map<string, number>();
+
+  constructor(readonly limits: ConnectionGatewayResourceLimits) {}
+
+  acquireConnection(): void {
+    if (this.activeConnections >= this.limits.maxConnections) {
+      throw createError(ErrorCode.connectionGatewayResourceLimitExceeded, {
+        data: { limit: 'maxConnections', max: this.limits.maxConnections }
+      });
+    }
+    this.activeConnections += 1;
+  }
+
+  releaseConnection(): void {
+    this.activeConnections = Math.max(0, this.activeConnections - 1);
+  }
+
+  assertSessionBudget(subject: string, activeSessions: number): void {
+    if (activeSessions >= this.limits.maxSessionsPerSubject) {
+      throw createError(ErrorCode.connectionGatewayResourceLimitExceeded, {
+        data: {
+          limit: 'maxSessionsPerSubject',
+          subject,
+          max: this.limits.maxSessionsPerSubject
+        }
+      });
+    }
+  }
+
+  acquireInFlight(sessionId: string): void {
+    const current = this.inFlightBySession.get(sessionId) ?? 0;
+    if (current >= this.limits.maxInFlightPerSession) {
+      throw createError(ErrorCode.connectionGatewayResourceLimitExceeded, {
+        data: {
+          limit: 'maxInFlightPerSession',
+          sessionId,
+          max: this.limits.maxInFlightPerSession
+        }
+      });
+    }
+
+    this.inFlightBySession.set(sessionId, current + 1);
+  }
+
+  releaseInFlight(sessionId: string): void {
+    const current = this.inFlightBySession.get(sessionId) ?? 0;
+    if (current <= 1) {
+      this.inFlightBySession.delete(sessionId);
+      return;
+    }
+
+    this.inFlightBySession.set(sessionId, current - 1);
+  }
+
+  assertEnvelopeBytes(value: unknown): number {
+    const bytes = Buffer.byteLength(JSON.stringify(value), 'utf8');
+
+    if (bytes > this.limits.maxEnvelopeBytes) {
+      throw createError(ErrorCode.connectionGatewayEnvelopeTooLarge, {
+        data: {
+          max: this.limits.maxEnvelopeBytes,
+          actual: bytes
+        }
+      });
+    }
+
+    return bytes;
+  }
+
+  getActiveConnections(): number {
+    return this.activeConnections;
+  }
+
+  getInFlightRequests(): number {
+    let count = 0;
+    for (const value of this.inFlightBySession.values()) {
+      count += value;
+    }
+    return count;
+  }
+}

--- a/packages/infrastructure/src/connection-gateway/service.test.ts
+++ b/packages/infrastructure/src/connection-gateway/service.test.ts
@@ -1,0 +1,145 @@
+import '@infrastructure/errors/error.registry';
+
+import { describe, expect, it } from 'vitest';
+
+import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
+
+import { InMemoryConnectionGatewayMailbox } from './mailbox';
+import { InMemoryConnectionGatewayMetrics } from './metrics';
+import { ConnectionGatewayResourceLimiter } from './resource-limiter';
+import { ConnectionGatewayService } from './service';
+import { InMemoryConnectionGatewaySessionRegistry } from './session-registry';
+import { HmacConnectionGatewayToken } from './token';
+
+const now = Date.now();
+
+function makeService(overrides: { maxSessionsPerSubject?: number } = {}) {
+  const limits = {
+    maxConnections: 10,
+    maxSessionsPerSubject: overrides.maxSessionsPerSubject ?? 5,
+    maxInFlightPerSession: 2,
+    maxEnvelopeBytes: 1024,
+    slowConsumerBufferBytes: 4096
+  };
+  const metrics = new InMemoryConnectionGatewayMetrics('node-a', limits);
+
+  return {
+    token: new HmacConnectionGatewayToken('secret'),
+    mailbox: new InMemoryConnectionGatewayMailbox(),
+    service: new ConnectionGatewayService({
+      tokenVerifier: new HmacConnectionGatewayToken('secret'),
+      sessionRegistry: new InMemoryConnectionGatewaySessionRegistry(),
+      mailbox: new InMemoryConnectionGatewayMailbox(),
+      metrics,
+      limiter: new ConnectionGatewayResourceLimiter(limits),
+      options: {
+        nodeId: 'node-a',
+        sessionTtlMs: 60_000,
+        ownerLeaseTtlMs: 15_000,
+        mailboxMaxLen: 100
+      }
+    }),
+    metrics
+  };
+}
+
+async function signDebugToken(token: HmacConnectionGatewayToken) {
+  return token.sign({
+    consumerType: 'plugin-debug',
+    subject: 'user:u1',
+    sessionScope: {
+      userId: 'u1',
+      source: 'debug:user:u1'
+    },
+    transport: 'tcp',
+    capabilities: ['invoke'],
+    issuedAt: now,
+    expiresAt: now + 60_000
+  });
+}
+
+function makeEnvelope(sessionId: string, generation: number): ConnectionGatewayEnvelope {
+  return {
+    protocol: 'connection-gateway.v1',
+    sessionId,
+    generation,
+    requestId: 'request-a',
+    type: 'request',
+    consumerType: 'plugin-debug',
+    capability: 'invoke',
+    createdAt: now,
+    payload: { ok: true }
+  };
+}
+
+describe('ConnectionGatewayService', () => {
+  it('creates scoped sessions and publishes opaque envelopes to the mailbox', async () => {
+    const { service, token, metrics } = makeService();
+    const session = await service.createSession({
+      token: await signDebugToken(token),
+      transport: 'tcp',
+      now
+    });
+
+    const result = await service.publishRequest({
+      sessionId: session.id,
+      envelope: makeEnvelope(session.id, session.generation)
+    });
+
+    await expect(service.getStatus(session.id)).resolves.toMatchObject({
+      session: expect.objectContaining({
+        id: session.id,
+        subject: 'user:u1',
+        generation: 0
+      }),
+      ownerAlive: true,
+      mailboxLag: 1
+    });
+    expect(result.accepted).toBe(true);
+    expect(metrics.snapshot()).toMatchObject({
+      activeSessions: 1,
+      mailbox: { lag: 1 }
+    });
+  });
+
+  it('fails closed for stale generation, missing capability, and subject session limits', async () => {
+    const { service, token } = makeService({ maxSessionsPerSubject: 1 });
+    const signed = await signDebugToken(token);
+    const session = await service.createSession({
+      token: signed,
+      transport: 'tcp',
+      now
+    });
+
+    await expect(
+      service.publishRequest({
+        sessionId: session.id,
+        envelope: makeEnvelope(session.id, session.generation + 1)
+      })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.stale_generation'
+    });
+
+    await expect(
+      service.publishRequest({
+        sessionId: session.id,
+        envelope: {
+          ...makeEnvelope(session.id, session.generation),
+          capability: 'admin'
+        }
+      })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.capability_denied'
+    });
+
+    await expect(
+      service.createSession({
+        token: signed,
+        transport: 'tcp',
+        now
+      })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.resource_limit_exceeded'
+    });
+  });
+});

--- a/packages/infrastructure/src/connection-gateway/service.ts
+++ b/packages/infrastructure/src/connection-gateway/service.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from 'node:crypto';
+
+import type { ConnectionGatewayMailboxPort } from '@domain/ports/connection-gateway/mailbox.port';
+import type { ConnectionGatewayMetricsPort } from '@domain/ports/connection-gateway/metrics.port';
+import type { ConnectionGatewaySessionRegistryPort } from '@domain/ports/connection-gateway/session-registry.port';
+import type { ConnectionGatewayTokenVerifierPort } from '@domain/ports/connection-gateway/connection-token.port';
+import {
+  type ConnectionGatewayEnvelope,
+  ConnectionGatewayEnvelopeSchema,
+  type ConnectionGatewaySession,
+  type ConnectionGatewaySessionStatusView,
+  type ConnectionGatewayTransport
+} from '@domain/value-objects/connection-gateway.vo';
+import { createError } from '@domain/value-objects/error.vo';
+
+import { ErrorCode } from '../errors/error.registry';
+
+import { ConnectionGatewayResourceLimiter } from './resource-limiter';
+
+type GatewayLogEntry = ConnectionGatewaySessionStatusView['logs'][number];
+
+export type ConnectionGatewayServiceOptions = {
+  nodeId: string;
+  sessionTtlMs: number;
+  ownerLeaseTtlMs: number;
+  mailboxMaxLen: number;
+};
+
+export type ConnectionGatewayServiceDeps = {
+  tokenVerifier: ConnectionGatewayTokenVerifierPort;
+  sessionRegistry: ConnectionGatewaySessionRegistryPort;
+  mailbox: ConnectionGatewayMailboxPort;
+  metrics: ConnectionGatewayMetricsPort;
+  limiter: ConnectionGatewayResourceLimiter;
+  options: ConnectionGatewayServiceOptions;
+};
+
+export class ConnectionGatewayService {
+  private readonly logs = new Map<string, GatewayLogEntry[]>();
+
+  constructor(private readonly deps: ConnectionGatewayServiceDeps) {}
+
+  metrics() {
+    return this.deps.metrics.snapshot();
+  }
+
+  async createSession(input: {
+    token: string;
+    transport: ConnectionGatewayTransport;
+    now?: number;
+  }): Promise<ConnectionGatewaySession> {
+    const now = input.now ?? Date.now();
+    const claims = await this.deps.tokenVerifier.verify({
+      token: input.token,
+      expectedTransport: input.transport,
+      now
+    });
+    const sessions = await this.deps.sessionRegistry.listBySubject(claims.subject);
+    this.deps.limiter.assertSessionBudget(claims.subject, sessions.length);
+
+    const expiresAt = now + this.deps.options.ownerLeaseTtlMs;
+    const session = await this.deps.sessionRegistry.create({
+      id: randomUUID(),
+      consumerType: claims.consumerType,
+      subject: claims.subject,
+      sessionScope: claims.sessionScope,
+      transport: claims.transport,
+      capabilities: claims.capabilities,
+      ownerNodeId: this.deps.options.nodeId,
+      expiresAt,
+      now
+    });
+
+    await this.deps.mailbox.expire(session.id, this.deps.options.sessionTtlMs);
+    this.deps.metrics.recordSessionOpened();
+    this.pushLog(session.id, 'info', 'Gateway session connected', {
+      consumerType: session.consumerType,
+      subject: session.subject,
+      transport: session.transport,
+      generation: session.generation
+    });
+
+    return session;
+  }
+
+  async getStatus(sessionId: string): Promise<ConnectionGatewaySessionStatusView> {
+    const session = await this.deps.sessionRegistry.get(sessionId);
+    const mailboxLag = await this.deps.mailbox.lag(sessionId);
+    this.deps.metrics.recordMailboxLag(mailboxLag);
+
+    return {
+      session,
+      ownerAlive: Boolean(session && session.expiresAt > Date.now()),
+      mailboxLag,
+      logs: this.logs.get(sessionId) ?? []
+    };
+  }
+
+  async publishRequest(input: {
+    sessionId: string;
+    envelope: ConnectionGatewayEnvelope;
+  }): Promise<{ messageId: string; accepted: true }> {
+    const envelope = ConnectionGatewayEnvelopeSchema.parse(input.envelope);
+    this.deps.limiter.assertEnvelopeBytes(envelope);
+
+    const session = await this.deps.sessionRegistry.get(input.sessionId);
+    if (!session) {
+      throw createError(ErrorCode.connectionGatewaySessionNotFound);
+    }
+
+    if (session.expiresAt <= Date.now()) {
+      this.deps.metrics.recordOwnerLeaseExpiry();
+      throw createError(ErrorCode.connectionGatewaySessionOwnerExpired);
+    }
+
+    if (envelope.generation !== session.generation) {
+      throw createError(ErrorCode.connectionGatewayStaleGeneration, {
+        data: {
+          expectedGeneration: session.generation,
+          actualGeneration: envelope.generation
+        }
+      });
+    }
+
+    if (envelope.consumerType !== session.consumerType) {
+      throw createError(ErrorCode.connectionGatewayInvalidToken, {
+        data: {
+          expectedConsumerType: session.consumerType,
+          actualConsumerType: envelope.consumerType
+        }
+      });
+    }
+
+    if (envelope.capability && !session.capabilities.includes(envelope.capability)) {
+      throw createError(ErrorCode.connectionGatewayCapabilityDenied, {
+        data: { capability: envelope.capability }
+      });
+    }
+
+    this.deps.limiter.acquireInFlight(session.id);
+    this.deps.metrics.recordRequestStarted(session.id);
+
+    try {
+      const messageId = await this.deps.mailbox.publish(session.id, envelope);
+      await this.deps.mailbox.trim(session.id, this.deps.options.mailboxMaxLen);
+      await this.deps.mailbox.expire(session.id, this.deps.options.sessionTtlMs);
+      const lag = await this.deps.mailbox.lag(session.id);
+      this.deps.metrics.recordMailboxLag(lag);
+      this.pushLog(session.id, 'debug', 'Gateway envelope published', {
+        messageId,
+        type: envelope.type,
+        requestId: envelope.requestId
+      });
+
+      return { messageId, accepted: true };
+    } finally {
+      this.deps.metrics.recordRequestCompleted(session.id);
+      this.deps.limiter.releaseInFlight(session.id);
+    }
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const session = await this.deps.sessionRegistry.get(sessionId);
+    await this.deps.sessionRegistry.remove(sessionId);
+    if (session) {
+      this.deps.metrics.recordSessionClosed();
+      this.pushLog(sessionId, 'info', 'Gateway session deleted');
+    }
+  }
+
+  async renewOwnerLease(sessionId: string, now = Date.now()): Promise<boolean> {
+    const renewed = await this.deps.sessionRegistry.renewOwnerLease({
+      sessionId,
+      ownerNodeId: this.deps.options.nodeId,
+      expiresAt: now + this.deps.options.ownerLeaseTtlMs,
+      now
+    });
+
+    if (renewed) {
+      this.pushLog(sessionId, 'debug', 'Gateway owner lease renewed');
+    }
+
+    return renewed;
+  }
+
+  private pushLog(
+    sessionId: string,
+    level: GatewayLogEntry['level'],
+    message: string,
+    data?: GatewayLogEntry['data']
+  ): void {
+    const logs = this.logs.get(sessionId) ?? [];
+    logs.push({
+      ts: Date.now(),
+      level,
+      message,
+      ...(data ? { data } : {})
+    });
+    this.logs.set(sessionId, logs.slice(-100));
+  }
+}

--- a/packages/infrastructure/src/connection-gateway/session-registry.ts
+++ b/packages/infrastructure/src/connection-gateway/session-registry.ts
@@ -1,0 +1,208 @@
+import type Redis from 'ioredis';
+
+import type {
+  ConnectionGatewaySessionRegistryPort,
+  CreateConnectionGatewaySessionInput,
+  RenewConnectionGatewayOwnerLeaseInput
+} from '@domain/ports/connection-gateway/session-registry.port';
+import {
+  type ConnectionGatewaySession,
+  ConnectionGatewaySessionSchema,
+  type ConnectionGatewaySessionStatus
+} from '@domain/value-objects/connection-gateway.vo';
+
+const SESSION_KEY_PREFIX = 'connection-gateway:sessions';
+
+export class InMemoryConnectionGatewaySessionRegistry
+  implements ConnectionGatewaySessionRegistryPort
+{
+  private readonly sessions = new Map<string, ConnectionGatewaySession>();
+
+  async create(input: CreateConnectionGatewaySessionInput): Promise<ConnectionGatewaySession> {
+    const now = input.now ?? Date.now();
+    const existing = this.sessions.get(input.id);
+    const session: ConnectionGatewaySession = {
+      ...input,
+      generation: input.generation ?? (existing ? existing.generation + 1 : 0),
+      status: input.status ?? 'connected',
+      connectedAt: now,
+      lastSeenAt: now
+    };
+
+    this.sessions.set(session.id, session);
+    return session;
+  }
+
+  async get(sessionId: string): Promise<ConnectionGatewaySession | null> {
+    this.dropExpired(Date.now());
+    return this.sessions.get(sessionId) ?? null;
+  }
+
+  async listBySubject(subject: string): Promise<ConnectionGatewaySession[]> {
+    this.dropExpired(Date.now());
+    return [...this.sessions.values()].filter((session) => session.subject === subject);
+  }
+
+  async renewOwnerLease(input: RenewConnectionGatewayOwnerLeaseInput): Promise<boolean> {
+    const session = await this.get(input.sessionId);
+    if (!session || session.ownerNodeId !== input.ownerNodeId) {
+      return false;
+    }
+
+    this.sessions.set(session.id, {
+      ...session,
+      expiresAt: input.expiresAt,
+      lastSeenAt: input.now ?? Date.now()
+    });
+    return true;
+  }
+
+  async updateStatus(input: {
+    sessionId: string;
+    ownerNodeId: string;
+    status: ConnectionGatewaySessionStatus;
+    now?: number;
+  }): Promise<boolean> {
+    const session = await this.get(input.sessionId);
+    if (!session || session.ownerNodeId !== input.ownerNodeId) {
+      return false;
+    }
+
+    this.sessions.set(session.id, {
+      ...session,
+      status: input.status,
+      lastSeenAt: input.now ?? Date.now()
+    });
+    return true;
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
+  }
+
+  async countActive(): Promise<number> {
+    this.dropExpired(Date.now());
+    return this.sessions.size;
+  }
+
+  private dropExpired(now: number): void {
+    for (const [sessionId, session] of this.sessions) {
+      if (session.expiresAt <= now) {
+        this.sessions.delete(sessionId);
+      }
+    }
+  }
+}
+
+export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewaySessionRegistryPort {
+  constructor(
+    private readonly redis: Redis,
+    private readonly ttlMs: number
+  ) {}
+
+  async create(input: CreateConnectionGatewaySessionInput): Promise<ConnectionGatewaySession> {
+    const now = input.now ?? Date.now();
+    const existing = await this.get(input.id);
+    const session: ConnectionGatewaySession = {
+      ...input,
+      generation: input.generation ?? (existing ? existing.generation + 1 : 0),
+      status: input.status ?? 'connected',
+      connectedAt: now,
+      lastSeenAt: now
+    };
+
+    await this.redis
+      .multi()
+      .set(this.sessionKey(session.id), JSON.stringify(session), 'PX', this.ttlMs)
+      .sadd(this.subjectKey(session.subject), session.id)
+      .pexpire(this.subjectKey(session.subject), this.ttlMs)
+      .exec();
+
+    return session;
+  }
+
+  async get(sessionId: string): Promise<ConnectionGatewaySession | null> {
+    const value = await this.redis.get(this.sessionKey(sessionId));
+    if (!value) {
+      return null;
+    }
+
+    const parsed = ConnectionGatewaySessionSchema.parse(JSON.parse(value));
+    if (parsed.expiresAt <= Date.now()) {
+      await this.redis
+        .multi()
+        .del(this.sessionKey(sessionId))
+        .srem(this.subjectKey(parsed.subject), sessionId)
+        .exec();
+      return null;
+    }
+
+    return parsed;
+  }
+
+  async listBySubject(subject: string): Promise<ConnectionGatewaySession[]> {
+    const sessionIds = await this.redis.smembers(this.subjectKey(subject));
+    const sessions = await Promise.all(sessionIds.map((sessionId) => this.get(sessionId)));
+
+    return sessions.filter((session): session is ConnectionGatewaySession => session !== null);
+  }
+
+  async renewOwnerLease(input: RenewConnectionGatewayOwnerLeaseInput): Promise<boolean> {
+    const session = await this.get(input.sessionId);
+    if (!session || session.ownerNodeId !== input.ownerNodeId) {
+      return false;
+    }
+
+    const next: ConnectionGatewaySession = {
+      ...session,
+      expiresAt: input.expiresAt,
+      lastSeenAt: input.now ?? Date.now()
+    };
+    await this.redis.set(this.sessionKey(session.id), JSON.stringify(next), 'PX', this.ttlMs);
+    return true;
+  }
+
+  async updateStatus(input: {
+    sessionId: string;
+    ownerNodeId: string;
+    status: ConnectionGatewaySessionStatus;
+    now?: number;
+  }): Promise<boolean> {
+    const session = await this.get(input.sessionId);
+    if (!session || session.ownerNodeId !== input.ownerNodeId) {
+      return false;
+    }
+
+    const next: ConnectionGatewaySession = {
+      ...session,
+      status: input.status,
+      lastSeenAt: input.now ?? Date.now()
+    };
+    await this.redis.set(this.sessionKey(session.id), JSON.stringify(next), 'PX', this.ttlMs);
+    return true;
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    const session = await this.get(sessionId);
+    const multi = this.redis.multi().del(this.sessionKey(sessionId));
+
+    if (session) {
+      multi.srem(this.subjectKey(session.subject), sessionId);
+    }
+
+    await multi.exec();
+  }
+
+  async countActive(): Promise<number> {
+    const keys = await this.redis.keys(`${SESSION_KEY_PREFIX}:by-id:*`);
+    return keys.length;
+  }
+
+  private sessionKey(sessionId: string): string {
+    return `${SESSION_KEY_PREFIX}:by-id:${sessionId}`;
+  }
+
+  private subjectKey(subject: string): string {
+    return `${SESSION_KEY_PREFIX}:by-subject:${subject}`;
+  }
+}

--- a/packages/infrastructure/src/connection-gateway/token.test.ts
+++ b/packages/infrastructure/src/connection-gateway/token.test.ts
@@ -1,0 +1,78 @@
+import '@infrastructure/errors/error.registry';
+
+import { describe, expect, it } from 'vitest';
+
+import { HmacConnectionGatewayToken } from './token';
+
+const now = 1_700_000_000_000;
+
+describe('HmacConnectionGatewayToken', () => {
+  it('signs and verifies scoped connection token claims', async () => {
+    const token = new HmacConnectionGatewayToken('secret');
+    const signed = await token.sign({
+      consumerType: 'plugin-debug',
+      subject: 'user:u1',
+      sessionScope: {
+        userId: 'u1',
+        source: 'debug:user:u1'
+      },
+      transport: 'tcp',
+      capabilities: ['invoke'],
+      issuedAt: now,
+      expiresAt: now + 60_000
+    });
+
+    await expect(
+      token.verify({
+        token: signed,
+        expectedTransport: 'tcp',
+        requiredCapability: 'invoke',
+        now
+      })
+    ).resolves.toMatchObject({
+      consumerType: 'plugin-debug',
+      subject: 'user:u1',
+      transport: 'tcp',
+      capabilities: ['invoke']
+    });
+  });
+
+  it('rejects expired, mismatched, and tampered tokens', async () => {
+    const token = new HmacConnectionGatewayToken('secret');
+    const signed = await token.sign({
+      consumerType: 'plugin-debug',
+      subject: 'user:u1',
+      sessionScope: {
+        userId: 'u1'
+      },
+      transport: 'tcp',
+      capabilities: [],
+      expiresAt: now - 1
+    });
+
+    await expect(token.verify({ token: signed, now })).rejects.toMatchObject({
+      code: 'connection_gateway.token_expired'
+    });
+
+    const fresh = await token.sign({
+      consumerType: 'plugin-debug',
+      subject: 'user:u1',
+      sessionScope: {
+        userId: 'u1'
+      },
+      transport: 'tcp',
+      capabilities: [],
+      expiresAt: now + 60_000
+    });
+
+    await expect(
+      token.verify({ token: fresh, expectedTransport: 'websocket', now })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.transport_mismatch'
+    });
+
+    await expect(token.verify({ token: `${fresh}x`, now })).rejects.toMatchObject({
+      code: 'connection_gateway.invalid_token'
+    });
+  });
+});

--- a/packages/infrastructure/src/connection-gateway/token.ts
+++ b/packages/infrastructure/src/connection-gateway/token.ts
@@ -1,0 +1,113 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import type {
+  ConnectionGatewayTokenSignerPort,
+  ConnectionGatewayTokenVerifierPort,
+  VerifyConnectionTokenInput
+} from '@domain/ports/connection-gateway/connection-token.port';
+import {
+  type ConnectionGatewayTokenClaims,
+  ConnectionGatewayTokenClaimsSchema
+} from '@domain/value-objects/connection-gateway.vo';
+import { createError } from '@domain/value-objects/error.vo';
+
+import { ErrorCode } from '../errors/error.registry';
+
+const TOKEN_HEADER = {
+  alg: 'HS256',
+  typ: 'CGT'
+} as const;
+
+export class HmacConnectionGatewayToken
+  implements ConnectionGatewayTokenSignerPort, ConnectionGatewayTokenVerifierPort
+{
+  constructor(private readonly secret: string) {}
+
+  async sign(claims: ConnectionGatewayTokenClaims): Promise<string> {
+    const parsed = ConnectionGatewayTokenClaimsSchema.parse(claims);
+    const header = encodeBase64Url(JSON.stringify(TOKEN_HEADER));
+    const payload = encodeBase64Url(JSON.stringify(parsed));
+    const signature = this.signSegments(header, payload);
+
+    return `${header}.${payload}.${signature}`;
+  }
+
+  async verify(input: VerifyConnectionTokenInput): Promise<ConnectionGatewayTokenClaims> {
+    const [header, payload, signature] = input.token.split('.');
+    if (!header || !payload || !signature) {
+      throw createError(ErrorCode.connectionGatewayInvalidToken);
+    }
+
+    const expectedSignature = this.signSegments(header, payload);
+    if (!safeEqual(signature, expectedSignature)) {
+      throw createError(ErrorCode.connectionGatewayInvalidToken);
+    }
+
+    const headerValue = parseBase64Json(header);
+    if (!isRecord(headerValue) || headerValue.alg !== TOKEN_HEADER.alg || headerValue.typ !== TOKEN_HEADER.typ) {
+      throw createError(ErrorCode.connectionGatewayInvalidToken);
+    }
+
+    const claims = ConnectionGatewayTokenClaimsSchema.parse(parseBase64Json(payload));
+    const now = input.now ?? Date.now();
+
+    if (claims.expiresAt <= now) {
+      throw createError(ErrorCode.connectionGatewayTokenExpired);
+    }
+
+    if (input.expectedTransport && claims.transport !== input.expectedTransport) {
+      throw createError(ErrorCode.connectionGatewayTransportMismatch, {
+        data: {
+          expectedTransport: input.expectedTransport,
+          actualTransport: claims.transport
+        }
+      });
+    }
+
+    if (
+      input.requiredCapability &&
+      !claims.capabilities.includes(input.requiredCapability)
+    ) {
+      throw createError(ErrorCode.connectionGatewayCapabilityDenied, {
+        data: {
+          requiredCapability: input.requiredCapability
+        }
+      });
+    }
+
+    return claims;
+  }
+
+  private signSegments(header: string, payload: string): string {
+    return encodeBase64Url(
+      createHmac('sha256', this.secret).update(`${header}.${payload}`).digest()
+    );
+  }
+}
+
+function encodeBase64Url(value: string | Buffer): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+function parseBase64Json(value: string): unknown {
+  try {
+    return JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as unknown;
+  } catch (error) {
+    throw createError(ErrorCode.connectionGatewayInvalidToken, { cause: error });
+  }
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.byteLength !== rightBuffer.byteLength) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/infrastructure/src/connection-gateway/transports/tcp-content-length-codec.test.ts
+++ b/packages/infrastructure/src/connection-gateway/transports/tcp-content-length-codec.test.ts
@@ -1,0 +1,41 @@
+import '@infrastructure/errors/error.registry';
+
+import { describe, expect, it } from 'vitest';
+
+import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
+
+import {
+  ContentLengthJsonFrameDecoder,
+  encodeContentLengthJsonFrame
+} from './tcp-content-length-codec';
+
+const envelope: ConnectionGatewayEnvelope = {
+  protocol: 'connection-gateway.v1',
+  sessionId: 'session-a',
+  generation: 0,
+  requestId: 'request-a',
+  type: 'request',
+  consumerType: 'plugin-debug',
+  capability: 'invoke',
+  createdAt: Date.now(),
+  payload: { value: 1 }
+};
+
+describe('ContentLengthJsonFrameDecoder', () => {
+  it('decodes split Content-Length JSON frames', () => {
+    const decoder = new ContentLengthJsonFrameDecoder(1024);
+    const frame = encodeContentLengthJsonFrame(envelope);
+    const first = frame.subarray(0, 8);
+    const second = frame.subarray(8);
+
+    expect(decoder.push(first)).toEqual([]);
+    expect(decoder.push(second)).toEqual([envelope]);
+  });
+
+  it('rejects oversized frames before reading the body', () => {
+    const decoder = new ContentLengthJsonFrameDecoder(4);
+    const frame = encodeContentLengthJsonFrame(envelope);
+
+    expect(() => decoder.push(frame)).toThrow();
+  });
+});

--- a/packages/infrastructure/src/connection-gateway/transports/tcp-content-length-codec.ts
+++ b/packages/infrastructure/src/connection-gateway/transports/tcp-content-length-codec.ts
@@ -1,0 +1,71 @@
+import {
+  type ConnectionGatewayEnvelope,
+  ConnectionGatewayEnvelopeSchema
+} from '@domain/value-objects/connection-gateway.vo';
+import { createError } from '@domain/value-objects/error.vo';
+
+import { ErrorCode } from '../../errors/error.registry';
+
+const HEADER_SEPARATOR = '\r\n\r\n';
+const CONTENT_LENGTH_HEADER = 'content-length';
+
+export function encodeContentLengthJsonFrame(envelope: ConnectionGatewayEnvelope): Buffer {
+  const body = Buffer.from(JSON.stringify(envelope), 'utf8');
+  const header = Buffer.from(`Content-Length: ${body.byteLength}${HEADER_SEPARATOR}`, 'utf8');
+
+  return Buffer.concat([header, body]);
+}
+
+export class ContentLengthJsonFrameDecoder {
+  private buffer = Buffer.alloc(0);
+
+  constructor(private readonly maxFrameBytes: number) {}
+
+  push(chunk: Buffer): ConnectionGatewayEnvelope[] {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const frames: ConnectionGatewayEnvelope[] = [];
+
+    while (true) {
+      const headerEnd = this.buffer.indexOf(HEADER_SEPARATOR);
+      if (headerEnd < 0) {
+        return frames;
+      }
+
+      const header = this.buffer.subarray(0, headerEnd).toString('utf8');
+      const contentLength = parseContentLength(header);
+      if (contentLength > this.maxFrameBytes) {
+        throw createError(ErrorCode.connectionGatewayEnvelopeTooLarge, {
+          data: { max: this.maxFrameBytes, actual: contentLength }
+        });
+      }
+
+      const bodyStart = headerEnd + Buffer.byteLength(HEADER_SEPARATOR);
+      const bodyEnd = bodyStart + contentLength;
+      if (this.buffer.byteLength < bodyEnd) {
+        return frames;
+      }
+
+      const body = this.buffer.subarray(bodyStart, bodyEnd).toString('utf8');
+      this.buffer = this.buffer.subarray(bodyEnd);
+      frames.push(ConnectionGatewayEnvelopeSchema.parse(JSON.parse(body)));
+    }
+  }
+}
+
+function parseContentLength(header: string): number {
+  const line = header
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .find((item) => item.toLowerCase().startsWith(`${CONTENT_LENGTH_HEADER}:`));
+
+  const value = line?.slice(line.indexOf(':') + 1).trim();
+  const contentLength = Number(value);
+
+  if (!Number.isSafeInteger(contentLength) || contentLength < 0) {
+    throw createError(ErrorCode.connectionGatewayInvalidToken, {
+      message: 'Invalid Content-Length frame'
+    });
+  }
+
+  return contentLength;
+}

--- a/packages/infrastructure/src/connection-gateway/transports/tcp-transport.ts
+++ b/packages/infrastructure/src/connection-gateway/transports/tcp-transport.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto';
+import net from 'node:net';
+
+import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
+
+import { ConnectionGatewayResourceLimiter } from '../resource-limiter';
+
+import {
+  ContentLengthJsonFrameDecoder,
+  encodeContentLengthJsonFrame
+} from './tcp-content-length-codec';
+import type {
+  ConnectionGatewayTransportConnection,
+  ConnectionGatewayTransportHandlers,
+  ConnectionGatewayTransportServer
+} from './transport';
+
+export type TcpConnectionGatewayTransportOptions = {
+  port: number;
+  host?: string;
+  maxFrameBytes: number;
+  limiter: ConnectionGatewayResourceLimiter;
+  handlers: ConnectionGatewayTransportHandlers;
+};
+
+class TcpGatewayConnection implements ConnectionGatewayTransportConnection {
+  readonly id = randomUUID();
+  readonly transport = 'tcp';
+  readonly remoteAddress?: string;
+
+  constructor(private readonly socket: net.Socket) {
+    this.remoteAddress = socket.remoteAddress;
+  }
+
+  async send(envelope: ConnectionGatewayEnvelope): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.socket.write(encodeContentLengthJsonFrame(envelope), (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  close(): void {
+    this.socket.end();
+  }
+}
+
+export class TcpConnectionGatewayTransport implements ConnectionGatewayTransportServer {
+  readonly transport = 'tcp';
+  private server: net.Server | null = null;
+
+  constructor(private readonly options: TcpConnectionGatewayTransportOptions) {}
+
+  async start(): Promise<void> {
+    if (this.server) {
+      return;
+    }
+
+    this.server = net.createServer((socket) => this.handleSocket(socket));
+
+    await new Promise<void>((resolve, reject) => {
+      this.server?.once('error', reject);
+      this.server?.listen(this.options.port, this.options.host, () => {
+        this.server?.off('error', reject);
+        resolve();
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    const server = this.server;
+    this.server = null;
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  private handleSocket(socket: net.Socket): void {
+    let connection: TcpGatewayConnection | null = null;
+
+    try {
+      this.options.limiter.acquireConnection();
+      connection = new TcpGatewayConnection(socket);
+      this.options.handlers.onConnection?.(connection);
+    } catch (error) {
+      socket.destroy(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    const decoder = new ContentLengthJsonFrameDecoder(this.options.maxFrameBytes);
+
+    socket.on('data', (chunk) => {
+      try {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        for (const envelope of decoder.push(buffer)) {
+          void Promise.resolve(this.options.handlers.onEnvelope(connection, envelope)).catch(
+            (error) => {
+              this.options.handlers.onError?.(connection, normalizeError(error));
+            }
+          );
+        }
+      } catch (error) {
+        const normalized = normalizeError(error);
+        this.options.handlers.onError?.(connection, normalized);
+        socket.destroy(normalized);
+      }
+    });
+
+    socket.once('close', () => {
+      this.options.limiter.releaseConnection();
+      this.options.handlers.onClose?.(connection);
+    });
+
+    socket.once('error', (error) => {
+      this.options.handlers.onError?.(connection, error);
+    });
+  }
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/infrastructure/src/connection-gateway/transports/transport.ts
+++ b/packages/infrastructure/src/connection-gateway/transports/transport.ts
@@ -1,0 +1,28 @@
+import type {
+  ConnectionGatewayEnvelope,
+  ConnectionGatewayTransport
+} from '@domain/value-objects/connection-gateway.vo';
+
+export type ConnectionGatewayTransportConnection = {
+  id: string;
+  transport: ConnectionGatewayTransport;
+  remoteAddress?: string;
+  send(envelope: ConnectionGatewayEnvelope): Promise<void>;
+  close(reason?: Error): void;
+};
+
+export type ConnectionGatewayTransportHandlers = {
+  onConnection?(connection: ConnectionGatewayTransportConnection): void;
+  onEnvelope(
+    connection: ConnectionGatewayTransportConnection,
+    envelope: ConnectionGatewayEnvelope
+  ): Promise<void> | void;
+  onClose?(connection: ConnectionGatewayTransportConnection, reason?: Error): void;
+  onError?(connection: ConnectionGatewayTransportConnection | null, error: Error): void;
+};
+
+export interface ConnectionGatewayTransportServer {
+  readonly transport: ConnectionGatewayTransport;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/packages/infrastructure/src/connection-gateway/transports/websocket-transport.ts
+++ b/packages/infrastructure/src/connection-gateway/transports/websocket-transport.ts
@@ -1,0 +1,17 @@
+import type { ConnectionGatewayTransportServer } from './transport';
+
+export type WebSocketConnectionGatewayTransportOptions = {
+  port: number;
+};
+
+export class WebSocketConnectionGatewayTransport implements ConnectionGatewayTransportServer {
+  readonly transport = 'websocket';
+
+  constructor(readonly options: WebSocketConnectionGatewayTransportOptions) {}
+
+  async start(): Promise<void> {
+    throw new Error('WebSocket Connection Gateway transport is not implemented yet');
+  }
+
+  async stop(): Promise<void> {}
+}

--- a/packages/infrastructure/src/env/index.ts
+++ b/packages/infrastructure/src/env/index.ts
@@ -57,6 +57,20 @@ export const env = createEnv({
     AUTH_TOKEN: AuthTokenSchema,
     JWT_SECRET: z.string().default('fastgpt-plugin-secret'),
 
+    // Connection Gateway 配置
+    CONNECTION_GATEWAY_PORT: PositiveIntSchema.min(1024).max(65535).default(3010),
+    CONNECTION_GATEWAY_TCP_PORT: PositiveIntSchema.min(1024).max(65535).default(3011),
+    CONNECTION_GATEWAY_NODE_ID: z.string().optional(),
+    CONNECTION_GATEWAY_SESSION_TTL_MS: PositiveIntSchema.default(60_000),
+    CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS: PositiveIntSchema.default(15_000),
+    CONNECTION_GATEWAY_MAILBOX_MAXLEN: PositiveIntSchema.default(1_000),
+    CONNECTION_GATEWAY_MAILBOX_BLOCK_MS: PositiveIntSchema.default(5_000),
+    CONNECTION_GATEWAY_MAX_CONNECTIONS: PositiveIntSchema.default(5_000),
+    CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT: PositiveIntSchema.default(5),
+    CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION: PositiveIntSchema.default(50),
+    CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES: PositiveIntSchema.default(1024 * 1024),
+    CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES: PositiveIntSchema.default(8 * 1024 * 1024),
+
     // 安全配置
     ALLOWED_INSTALL_HOSTS: z.string().optional(),
     DISABLE_SSRF_CHECK: BoolStringSchema.default(false),

--- a/packages/infrastructure/src/errors/error.registry.ts
+++ b/packages/infrastructure/src/errors/error.registry.ts
@@ -23,7 +23,16 @@ export const ErrorCode = {
   pluginRuntimeShutdownFailed: 'plugin.runtime.shutdown_failed',
   pluginInvokeFailed: 'plugin.invoke.failed',
   pluginInvokeTimeout: 'plugin.invoke.timeout',
-  pluginInvokeQueueTimeout: 'plugin.invoke.queue_timeout'
+  pluginInvokeQueueTimeout: 'plugin.invoke.queue_timeout',
+  connectionGatewayInvalidToken: 'connection_gateway.invalid_token',
+  connectionGatewayTokenExpired: 'connection_gateway.token_expired',
+  connectionGatewayTransportMismatch: 'connection_gateway.transport_mismatch',
+  connectionGatewayCapabilityDenied: 'connection_gateway.capability_denied',
+  connectionGatewayStaleGeneration: 'connection_gateway.stale_generation',
+  connectionGatewaySessionNotFound: 'connection_gateway.session_not_found',
+  connectionGatewaySessionOwnerExpired: 'connection_gateway.session_owner_expired',
+  connectionGatewayResourceLimitExceeded: 'connection_gateway.resource_limit_exceeded',
+  connectionGatewayEnvelopeTooLarge: 'connection_gateway.envelope_too_large'
 } as const;
 
 registerErrors([
@@ -175,5 +184,68 @@ registerErrors([
     },
     httpStatus: 503,
     telemetryKind: 'queue_timeout'
+  },
+  {
+    code: ErrorCode.connectionGatewayInvalidToken,
+    message: 'Invalid connection token',
+    reason: { en: 'Invalid connection token', 'zh-CN': '连接令牌无效' },
+    httpStatus: 401,
+    telemetryKind: 'connection_gateway_invalid_token'
+  },
+  {
+    code: ErrorCode.connectionGatewayTokenExpired,
+    message: 'Connection token expired',
+    reason: { en: 'Connection token expired', 'zh-CN': '连接令牌已过期' },
+    httpStatus: 401,
+    telemetryKind: 'connection_gateway_token_expired'
+  },
+  {
+    code: ErrorCode.connectionGatewayTransportMismatch,
+    message: 'Connection token transport mismatch',
+    reason: { en: 'Connection token transport mismatch', 'zh-CN': '连接令牌传输类型不匹配' },
+    httpStatus: 400,
+    telemetryKind: 'connection_gateway_transport_mismatch'
+  },
+  {
+    code: ErrorCode.connectionGatewayCapabilityDenied,
+    message: 'Connection token capability denied',
+    reason: { en: 'Connection token capability denied', 'zh-CN': '连接令牌缺少能力授权' },
+    httpStatus: 403,
+    telemetryKind: 'connection_gateway_capability_denied'
+  },
+  {
+    code: ErrorCode.connectionGatewayStaleGeneration,
+    message: 'Stale gateway generation',
+    reason: { en: 'Stale gateway generation', 'zh-CN': 'Gateway generation 已过期' },
+    httpStatus: 409,
+    telemetryKind: 'connection_gateway_stale_generation'
+  },
+  {
+    code: ErrorCode.connectionGatewaySessionNotFound,
+    message: 'Gateway session not found',
+    reason: { en: 'Gateway session not found', 'zh-CN': 'Gateway 会话不存在' },
+    httpStatus: 404,
+    telemetryKind: 'connection_gateway_session_not_found'
+  },
+  {
+    code: ErrorCode.connectionGatewaySessionOwnerExpired,
+    message: 'Gateway session owner expired',
+    reason: { en: 'Gateway session owner expired', 'zh-CN': 'Gateway 会话 owner 已过期' },
+    httpStatus: 409,
+    telemetryKind: 'connection_gateway_session_owner_expired'
+  },
+  {
+    code: ErrorCode.connectionGatewayResourceLimitExceeded,
+    message: 'Gateway resource limit exceeded',
+    reason: { en: 'Gateway resource limit exceeded', 'zh-CN': 'Gateway 资源限制已达到' },
+    httpStatus: 429,
+    telemetryKind: 'connection_gateway_resource_limit_exceeded'
+  },
+  {
+    code: ErrorCode.connectionGatewayEnvelopeTooLarge,
+    message: 'Gateway envelope too large',
+    reason: { en: 'Gateway envelope too large', 'zh-CN': 'Gateway 消息体过大' },
+    httpStatus: 413,
+    telemetryKind: 'connection_gateway_envelope_too_large'
   }
 ]);

--- a/packages/interface-adapter/src/contracts/contract.type.ts
+++ b/packages/interface-adapter/src/contracts/contract.type.ts
@@ -6,7 +6,8 @@ export const OpenAPITagsEnum = {
   plugin: 'plugin',
   tool: 'tool',
   model: 'model',
-  workflow: 'workflow'
+  workflow: 'workflow',
+  connectionGateway: 'connection-gateway'
 } as const;
 
 export type OpenAPITagsType = (typeof OpenAPITagsEnum)[keyof typeof OpenAPITagsEnum];

--- a/packages/interface-adapter/src/contracts/dto/connection-gateway.dto.ts
+++ b/packages/interface-adapter/src/contracts/dto/connection-gateway.dto.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+import {
+  ConnectionGatewayEnvelopeSchema,
+  ConnectionGatewayMetricsSchema,
+  ConnectionGatewaySessionSchema,
+  ConnectionGatewaySessionStatusViewSchema,
+  ConnectionGatewayTokenClaimsSchema
+} from '@domain/value-objects/connection-gateway.vo';
+
+export const ConnectionGatewayCreateSessionRequestDTOSchema = z.object({
+  token: z.string().min(1),
+  transport: z.enum(['tcp', 'websocket'])
+});
+export type ConnectionGatewayCreateSessionRequestDTO = z.infer<
+  typeof ConnectionGatewayCreateSessionRequestDTOSchema
+>;
+
+export const ConnectionGatewayCreateSessionResponseDTOSchema = z.object({
+  session: ConnectionGatewaySessionSchema
+});
+export type ConnectionGatewayCreateSessionResponseDTO = z.infer<
+  typeof ConnectionGatewayCreateSessionResponseDTOSchema
+>;
+
+export const ConnectionGatewayRequestDTOSchema = z.object({
+  envelope: ConnectionGatewayEnvelopeSchema,
+  stream: z.boolean().default(false)
+});
+export type ConnectionGatewayRequestDTO = z.infer<typeof ConnectionGatewayRequestDTOSchema>;
+
+export const ConnectionGatewayRequestAcceptedDTOSchema = z.object({
+  messageId: z.string(),
+  accepted: z.literal(true)
+});
+export type ConnectionGatewayRequestAcceptedDTO = z.infer<
+  typeof ConnectionGatewayRequestAcceptedDTOSchema
+>;
+
+export const ConnectionGatewayTokenClaimsDTOSchema = ConnectionGatewayTokenClaimsSchema;
+export const ConnectionGatewayMetricsDTOSchema = ConnectionGatewayMetricsSchema;
+export const ConnectionGatewaySessionStatusViewDTOSchema =
+  ConnectionGatewaySessionStatusViewSchema;

--- a/packages/interface-adapter/src/contracts/dto/index.ts
+++ b/packages/interface-adapter/src/contracts/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './common.dto';
+export * from './connection-gateway.dto';
 export * from './model.dto';
 export * from './plugin.dto';
 export * from './tool.dto';

--- a/packages/interface-adapter/src/contracts/index.ts
+++ b/packages/interface-adapter/src/contracts/index.ts
@@ -1,3 +1,4 @@
+import { ConnectionGatewayContract } from './route/connection-gateway.contract';
 import { ModelContract } from './route/model.contract';
 import { PluginContract } from './route/plugin.contract';
 import { ToolContract } from './route/tool.contract';
@@ -5,6 +6,7 @@ import { WorkflowContract } from './route/workflow.contract';
 import type { ContractItemType } from './contract.type';
 
 export default [
+  ...Object.values(ConnectionGatewayContract),
   ...Object.values(ModelContract),
   ...Object.values(PluginContract),
   ...Object.values(ToolContract),

--- a/packages/interface-adapter/src/contracts/route/connection-gateway.contract.ts
+++ b/packages/interface-adapter/src/contracts/route/connection-gateway.contract.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+
+import { defineContract, jsonResponse, type ContractMetaType } from '../contract.type';
+import { ErrorResponseDTOSchema } from '../dto/common.dto';
+import {
+  ConnectionGatewayCreateSessionRequestDTOSchema,
+  ConnectionGatewayCreateSessionResponseDTOSchema,
+  ConnectionGatewayMetricsDTOSchema,
+  ConnectionGatewayRequestAcceptedDTOSchema,
+  ConnectionGatewayRequestDTOSchema,
+  ConnectionGatewaySessionStatusViewDTOSchema
+} from '../dto/connection-gateway.dto';
+
+const tags = ['connection-gateway'] satisfies ContractMetaType['tags'];
+
+export const ConnectionGatewayContract = {
+  Metrics: defineContract({
+    meta: {
+      method: 'get',
+      path: '/metrics',
+      operationId: 'connectionGateway.metrics',
+      summary: 'Connection Gateway metrics',
+      tags
+    },
+    response: {
+      200: jsonResponse({ data: ConnectionGatewayMetricsDTOSchema }),
+      500: jsonResponse({ error: ErrorResponseDTOSchema })
+    }
+  }),
+  CreateSession: defineContract({
+    meta: {
+      method: 'post',
+      path: '/internal/sessions',
+      operationId: 'connectionGateway.createSession',
+      summary: 'Create a gateway session',
+      tags
+    },
+    request: ConnectionGatewayCreateSessionRequestDTOSchema,
+    response: {
+      200: jsonResponse({ data: ConnectionGatewayCreateSessionResponseDTOSchema }),
+      400: jsonResponse({ error: ErrorResponseDTOSchema }),
+      429: jsonResponse({ error: ErrorResponseDTOSchema })
+    }
+  }),
+  SessionStatus: defineContract({
+    meta: {
+      method: 'get',
+      path: '/internal/sessions/{sessionId}/status',
+      operationId: 'connectionGateway.sessionStatus',
+      summary: 'Get a gateway session status',
+      tags
+    },
+    request: z.object({
+      sessionId: z.string().min(1)
+    }),
+    response: {
+      200: jsonResponse({ data: ConnectionGatewaySessionStatusViewDTOSchema }),
+      404: jsonResponse({ error: ErrorResponseDTOSchema })
+    }
+  }),
+  PublishRequest: defineContract({
+    meta: {
+      method: 'post',
+      path: '/internal/sessions/{sessionId}/requests',
+      operationId: 'connectionGateway.publishRequest',
+      summary: 'Publish an opaque request envelope to a gateway session mailbox',
+      tags
+    },
+    request: z.object({
+      sessionId: z.string().min(1),
+      body: ConnectionGatewayRequestDTOSchema
+    }),
+    response: {
+      202: jsonResponse({ data: ConnectionGatewayRequestAcceptedDTOSchema }),
+      400: jsonResponse({ error: ErrorResponseDTOSchema }),
+      404: jsonResponse({ error: ErrorResponseDTOSchema }),
+      409: jsonResponse({ error: ErrorResponseDTOSchema }),
+      429: jsonResponse({ error: ErrorResponseDTOSchema })
+    }
+  }),
+  DeleteSession: defineContract({
+    meta: {
+      method: 'delete',
+      path: '/internal/sessions/{sessionId}',
+      operationId: 'connectionGateway.deleteSession',
+      summary: 'Delete a gateway session',
+      tags
+    },
+    request: z.object({
+      sessionId: z.string().min(1)
+    }),
+    response: {
+      200: jsonResponse({ data: z.object({ deleted: z.boolean() }) })
+    }
+  })
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,40 @@ importers:
         specifier: ^4.0.18
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/coverage-v8@3.1.2(vitest@3.2.6(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  apps/connection-gateway:
+    dependencies:
+      '@fastgpt-plugin/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
+      '@fastgpt-plugin/infrastructure':
+        specifier: workspace:*
+        version: link:../../packages/infrastructure
+      '@fastgpt-plugin/interface-adapter':
+        specifier: workspace:*
+        version: link:../../packages/interface-adapter
+      '@fastgpt-plugin/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@hono/node-server':
+        specifier: ^1.19.9
+        version: 1.19.10(hono@4.12.21)
+      hono:
+        specifier: ^4.12.21
+        version: 4.12.21
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   apps/debug-runtime-monitor:
     devDependencies:
       typescript:

--- a/scripts/connection-gateway-create-session.mjs
+++ b/scripts/connection-gateway-create-session.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+import { createHmac, randomUUID } from 'node:crypto';
+import net from 'node:net';
+
+const TOKEN_HEADER = {
+  alg: 'HS256',
+  typ: 'CGT'
+};
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printUsage();
+    return;
+  }
+
+  validateRequiredOptions(options);
+
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const now = Date.now();
+  const claims = {
+    consumerType: options.consumerType,
+    subject: options.subject,
+    sessionScope: {
+      userId: options.userId,
+      ...(options.teamId ? { teamId: options.teamId } : {}),
+      source: options.source
+    },
+    transport: options.transport,
+    capabilities: options.capabilities,
+    issuedAt: now,
+    expiresAt: now + options.tokenTtlMs,
+    nonce: randomUUID()
+  };
+  const connectionToken = signConnectionToken(claims, options.jwtSecret);
+  const sessionPayload = await createSession({
+    baseUrl,
+    authToken: options.authToken,
+    connectionToken,
+    transport: options.transport
+  });
+  const session = unwrapData(sessionPayload).session;
+
+  console.log('Session created:');
+  console.log(JSON.stringify({ session, claims }, null, 2));
+
+  if (options.tcpPing) {
+    await sendTcpPing({
+      host: options.tcpHost,
+      port: options.tcpPort,
+      session,
+      capability: options.tcpCapability
+    });
+
+    const statusPayload = await getSessionStatus({
+      baseUrl,
+      authToken: options.authToken,
+      sessionId: session.id
+    });
+
+    console.log('TCP ping sent. Session status:');
+    console.log(JSON.stringify(unwrapData(statusPayload), null, 2));
+  }
+}
+
+function parseArgs(args) {
+  const options = {
+    authToken: process.env.AUTH_TOKEN || 'token',
+    baseUrl: process.env.CONNECTION_GATEWAY_BASE_URL || 'http://127.0.0.1:3010',
+    capabilities: parseList(process.env.CONNECTION_GATEWAY_CAPABILITIES || 'invoke'),
+    consumerType: process.env.CONNECTION_GATEWAY_CONSUMER_TYPE || 'plugin-debug',
+    help: false,
+    jwtSecret: process.env.JWT_SECRET || 'fastgpt-plugin-secret',
+    source: process.env.CONNECTION_GATEWAY_SOURCE,
+    subject: process.env.CONNECTION_GATEWAY_SUBJECT,
+    tcpCapability: process.env.CONNECTION_GATEWAY_TCP_CAPABILITY || 'invoke',
+    tcpHost: process.env.CONNECTION_GATEWAY_TCP_HOST || '127.0.0.1',
+    tcpPing: false,
+    tcpPort: Number(process.env.CONNECTION_GATEWAY_TCP_PORT || 3011),
+    teamId: process.env.CONNECTION_GATEWAY_TEAM_ID,
+    tokenTtlMs: Number(process.env.CONNECTION_GATEWAY_TOKEN_TTL_MS || 5 * 60_000),
+    transport: process.env.CONNECTION_GATEWAY_TRANSPORT || 'tcp',
+    userId: process.env.CONNECTION_GATEWAY_USER_ID || 'debug-user'
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--tcp-ping') {
+      options.tcpPing = true;
+      continue;
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const { key, value, nextIndex } = readLongOption(args, index);
+    index = nextIndex;
+
+    switch (key) {
+      case 'auth-token':
+      case 'token':
+        options.authToken = value;
+        break;
+      case 'base-url':
+      case 'baseurl':
+        options.baseUrl = value;
+        break;
+      case 'capabilities':
+        options.capabilities = parseList(value);
+        break;
+      case 'consumer-type':
+        options.consumerType = value;
+        break;
+      case 'jwt-secret':
+        options.jwtSecret = value;
+        break;
+      case 'source':
+        options.source = value;
+        break;
+      case 'subject':
+        options.subject = value;
+        break;
+      case 'tcp-capability':
+        options.tcpCapability = value;
+        break;
+      case 'tcp-host':
+        options.tcpHost = value;
+        break;
+      case 'tcp-port':
+        options.tcpPort = Number(value);
+        break;
+      case 'team-id':
+        options.teamId = value;
+        break;
+      case 'token-ttl-ms':
+        options.tokenTtlMs = Number(value);
+        break;
+      case 'transport':
+        options.transport = value;
+        break;
+      case 'user-id':
+        options.userId = value;
+        break;
+      default:
+        throw new Error(`Unknown option: --${key}`);
+    }
+  }
+
+  options.subject ||= `user:${options.userId}`;
+  options.source ||= `debug:user:${options.userId}`;
+
+  return options;
+}
+
+function readLongOption(args, index) {
+  const arg = args[index];
+  const equalIndex = arg.indexOf('=');
+
+  if (equalIndex > -1) {
+    return {
+      key: arg.slice(2, equalIndex),
+      value: arg.slice(equalIndex + 1),
+      nextIndex: index
+    };
+  }
+
+  const value = args[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`Missing value for ${arg}.`);
+  }
+
+  return {
+    key: arg.slice(2),
+    value,
+    nextIndex: index + 1
+  };
+}
+
+function validateRequiredOptions(options) {
+  const missing = [];
+
+  if (!options.authToken) missing.push('auth-token');
+  if (!options.baseUrl) missing.push('base-url');
+  if (!options.jwtSecret) missing.push('jwt-secret');
+  if (!options.subject) missing.push('subject');
+  if (!options.userId) missing.push('user-id');
+  if (!['tcp', 'websocket'].includes(options.transport)) missing.push('transport(tcp|websocket)');
+  if (!Number.isSafeInteger(options.tokenTtlMs) || options.tokenTtlMs <= 0) {
+    missing.push('token-ttl-ms');
+  }
+  if (options.tcpPing && (!Number.isSafeInteger(options.tcpPort) || options.tcpPort <= 0)) {
+    missing.push('tcp-port');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing or invalid options: ${missing.join(', ')}\n\n${usageText()}`);
+  }
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('base-url only supports http or https.');
+  }
+  url.hash = '';
+  url.search = '';
+
+  return url.toString().replace(/\/+$/, '');
+}
+
+function signConnectionToken(claims, secret) {
+  const header = encodeBase64Url(JSON.stringify(TOKEN_HEADER));
+  const payload = encodeBase64Url(JSON.stringify(claims));
+  const signature = encodeBase64Url(createHmac('sha256', secret).update(`${header}.${payload}`).digest());
+
+  return `${header}.${payload}.${signature}`;
+}
+
+async function createSession({ baseUrl, authToken, connectionToken, transport }) {
+  return postJson({
+    url: `${baseUrl}/internal/sessions`,
+    authToken,
+    body: {
+      token: connectionToken,
+      transport
+    }
+  });
+}
+
+async function getSessionStatus({ baseUrl, authToken, sessionId }) {
+  const response = await fetch(`${baseUrl}/internal/sessions/${encodeURIComponent(sessionId)}/status`, {
+    headers: {
+      Authorization: `Bearer ${authToken}`
+    }
+  });
+
+  return parseResponse(response);
+}
+
+async function postJson({ url, authToken, body }) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+
+  return parseResponse(response);
+}
+
+async function parseResponse(response) {
+  const text = await response.text();
+  let payload;
+
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = { raw: text };
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Gateway request failed: ${response.status} ${response.statusText}\n${JSON.stringify(payload, null, 2)}`
+    );
+  }
+
+  return payload;
+}
+
+async function sendTcpPing({ host, port, session, capability }) {
+  const envelope = {
+    protocol: 'connection-gateway.v1',
+    sessionId: session.id,
+    generation: session.generation,
+    requestId: randomUUID(),
+    type: 'request',
+    consumerType: session.consumerType,
+    capability,
+    createdAt: Date.now(),
+    payload: {
+      ping: true,
+      sentAt: new Date().toISOString()
+    }
+  };
+  const body = JSON.stringify(envelope);
+  const frame = `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`;
+
+  await new Promise((resolve, reject) => {
+    const socket = net.connect(port, host, () => {
+      socket.end(frame);
+    });
+
+    socket.once('close', resolve);
+    socket.once('error', reject);
+  });
+}
+
+function unwrapData(payload) {
+  if (!payload || typeof payload !== 'object' || !('data' in payload)) {
+    throw new Error(`Gateway response missing data: ${JSON.stringify(payload, null, 2)}`);
+  }
+
+  return payload.data;
+}
+
+function encodeBase64Url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function parseList(value) {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function printUsage() {
+  console.log(usageText());
+}
+
+function usageText() {
+  return `
+Usage:
+  node scripts/connection-gateway-create-session.mjs [options]
+
+Options:
+  --base-url <url>          Gateway HTTP base URL. Default: CONNECTION_GATEWAY_BASE_URL or http://127.0.0.1:3010
+  --auth-token <token>      Gateway AUTH_TOKEN. Default: AUTH_TOKEN or token
+  --jwt-secret <secret>     Gateway JWT_SECRET. Default: JWT_SECRET or fastgpt-plugin-secret
+  --user-id <id>            sessionScope.userId. Default: CONNECTION_GATEWAY_USER_ID or debug-user
+  --subject <subject>       Token subject. Default: user:<user-id>
+  --source <source>         sessionScope.source. Default: debug:user:<user-id>
+  --consumer-type <type>    Default: plugin-debug
+  --capabilities <list>     Comma-separated capabilities. Default: invoke
+  --transport <transport>   tcp or websocket. Default: tcp
+  --token-ttl-ms <ms>       Connection token TTL. Default: 300000
+  --tcp-ping                After creating the session, send a TCP ping envelope to the mailbox.
+  --tcp-host <host>         TCP host for --tcp-ping. Default: 127.0.0.1
+  --tcp-port <port>         TCP port for --tcp-ping. Default: CONNECTION_GATEWAY_TCP_PORT or 3011
+`.trim();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a standalone connection-gateway app with HTTP routes, domain ports, DTO contracts, token/session/mailbox services, metrics, limits, and TCP/WebSocket transport foundations.
- Add deployment support through a multi-stage Dockerfile that can build target-platform runner images for Kubernetes nodes.
- Add a local session helper script for creating sessions and optionally sending a TCP ping frame during test-environment validation.

## Verification
- pnpm exec tsc --noEmit --pretty false
- pnpm test
- pnpm build:connection-gateway
- docker build --platform linux/amd64 -f apps/connection-gateway/Dockerfile --target runner -t fastgpt-plugin-connection-gateway:amd64-test .
- node --check scripts/connection-gateway-create-session.mjs
- git diff --check upstream/dev/tcp-debug...HEAD

## Notes
- Base branch is dev/tcp-debug.
- This PR is the foundation layer. The plugin debug consumer/runtime wiring remains for the next PR.
- TCP frames currently require a session created by the HTTP internal session API first.