### PR TITLE
feat: add connection gateway debug runtime

### DIFF
--- a/apps/cli/src/commands/debug.spec.ts
+++ b/apps/cli/src/commands/debug.spec.ts
@@ -3,10 +3,19 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { connectDebugGateway } from '@fastgpt-plugin/cli/debug/gateway';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { run } from '../cmd';
 import { logger } from '../helpers';
+
+const { connectDebugGatewayMock } = vi.hoisted(() => ({
+  connectDebugGatewayMock: vi.fn()
+}));
+
+vi.mock('@fastgpt-plugin/cli/debug/gateway', () => ({
+  connectDebugGateway: connectDebugGatewayMock
+}));
 
 const FIXTURE_ROOT = fileURLToPath(new URL('../../../../test/fixtures/', import.meta.url));
 const GETTIME_TOOL_DIR = path.join(FIXTURE_ROOT, 'tools', 'getTime');
@@ -27,6 +36,28 @@ describe('debug command', () => {
     vi.spyOn(logger, 'info').mockImplementation(loggerSpy.info);
     vi.spyOn(logger, 'error').mockImplementation(loggerSpy.error);
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    vi.mocked(connectDebugGateway).mockImplementation(async ({ options }) => ({
+      session: {
+        id: 'session-debug',
+        consumerType: 'plugin-debug',
+        subject: `user:${options.userId}`,
+        sessionScope: {
+          userId: options.userId,
+          source: options.source
+        },
+        transport: 'tcp',
+        capabilities: ['invoke'],
+        generation: 0,
+        ownerNodeId: 'node-a',
+        status: 'connected',
+        connectedAt: Date.now(),
+        lastSeenAt: Date.now(),
+        expiresAt: Date.now() + 60_000
+      },
+      close: vi.fn(),
+      closed: Promise.resolve()
+    }));
+    connectDebugGatewayMock.mockClear();
     tempUploadDir = await mkdtemp(path.join(tmpdir(), 'fastgpt-plugin-debug-'));
   });
 
@@ -35,6 +66,7 @@ describe('debug command', () => {
     loggerSpy.success.mockReset();
     loggerSpy.info.mockReset();
     loggerSpy.error.mockReset();
+    delete process.env.CONNECTION_GATEWAY_AUTH_TOKEN;
     await rm(tempUploadDir, { recursive: true, force: true });
   });
 
@@ -101,6 +133,91 @@ describe('debug command', () => {
     expect(uploadedContent).toBe('hello upload');
     expect(infoOutput).toContain('"fileName": "echo.txt"');
     expect(infoOutput).toContain('"accessURL"');
+    expect(loggerSpy.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('应能连接 Connection Gateway 等待远程调试请求', async () => {
+    await run([
+      process.execPath,
+      'cli',
+      'debug',
+      GETTIME_TOOL_DIR,
+      '--gateway',
+      '--gateway-user-id',
+      'u1',
+      '--gateway-source',
+      'debug:user:u1'
+    ]);
+
+    const successOutput = getLoggerOutput(loggerSpy.success);
+
+    expect(successOutput).toContain('远程调试已就绪: debug:user:u1 getTime');
+    expect(loggerSpy.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('应能通过 tcp URL 连接 Connection Gateway', async () => {
+    await run([
+      process.execPath,
+      'cli',
+      'debug',
+      GETTIME_TOOL_DIR,
+      '--gateway',
+      '--gateway-user-id',
+      'u1',
+      '--gateway-tcp-url',
+      'tcp://tcp.example.com:39430'
+    ]);
+
+    expect(vi.mocked(connectDebugGateway).mock.calls[0]?.[0].options).toMatchObject({
+      tcpHost: 'tcp.example.com',
+      tcpPort: 39430
+    });
+    expect(loggerSpy.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('应能通过 CONNECTION_GATEWAY_AUTH_TOKEN 配置 gateway token', async () => {
+    process.env.CONNECTION_GATEWAY_AUTH_TOKEN = 'gateway-token-from-env';
+
+    await run([
+      process.execPath,
+      'cli',
+      'debug',
+      GETTIME_TOOL_DIR,
+      '--gateway',
+      '--gateway-user-id',
+      'u1'
+    ]);
+
+    expect(vi.mocked(connectDebugGateway).mock.calls[0]?.[0].options).toMatchObject({
+      authToken: 'gateway-token-from-env'
+    });
+    expect(loggerSpy.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('应能在一个 CLI 进程内为多个插件建立远程调试通道', async () => {
+    await run([
+      process.execPath,
+      'cli',
+      'debug',
+      GETTIME_TOOL_DIR,
+      DBOPS_SUITE_DIR,
+      '--gateway',
+      '--gateway-user-id',
+      'u1'
+    ]);
+
+    const successOutput = getLoggerOutput(loggerSpy.success);
+    const infoOutput = getLoggerOutput(loggerSpy.info);
+
+    expect(vi.mocked(connectDebugGateway)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(connectDebugGateway).mock.calls[0]?.[0].targets).toHaveLength(2);
+    expect(successOutput).toContain('远程调试已就绪: debug:user:u1 getTime');
+    expect(successOutput).toContain('远程调试已就绪: debug:user:u1 dbops');
+    expect(infoOutput).toContain('已建立 1 个远程调试通道，挂载 2 个插件');
     expect(loggerSpy.error).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/apps/cli/src/commands/debug.ts
+++ b/apps/cli/src/commands/debug.ts
@@ -3,6 +3,11 @@ import path from 'node:path';
 
 import { BaseCommand } from '@fastgpt-plugin/cli/commands/base';
 import {
+  connectDebugGateway,
+  type DebugGatewayClientOptions,
+  type DebugGatewayTarget
+} from '@fastgpt-plugin/cli/debug/gateway';
+import {
   type DebugPluginSnapshot,
   type DebugToolSnapshot,
   loadDebugSession,
@@ -24,12 +29,24 @@ type DebugCommandOptions = {
   systemVar?: string;
   systemVarFile?: string;
   uploadDir?: string;
+  gateway?: boolean;
+  gatewayBaseUrl?: string;
+  gatewayAuthToken?: string;
+  gatewayJwtSecret?: string;
+  gatewayTcpUrl?: string;
+  gatewayTcpHost?: string;
+  gatewayTcpPort?: string;
+  gatewayUserId?: string;
+  gatewayTeamId?: string;
+  gatewaySource?: string;
+  gatewaySubject?: string;
+  gatewayTokenTtlMs?: string;
 };
 
 export class DebugCommand extends BaseCommand {
   public register(parent: Command): void {
     parent
-      .command('debug <entry>')
+      .command('debug <entries...>')
       .description('直接加载本地插件目录并调试工具')
       .option('-t, --tool <childId>', '工具集子工具 ID')
       .option('--run', '立即执行一次工具调试', false)
@@ -40,22 +57,72 @@ export class DebugCommand extends BaseCommand {
       .option('--system-var <json>', 'systemVar JSON 字符串')
       .option('--system-var-file <path>', 'systemVar JSON 文件路径')
       .option('--upload-dir <path>', '虚拟 uploadFile 的输出目录')
-      .action(async (entry: string, opts: DebugCommandOptions) => {
-        await this.run(entry, opts);
+      .option('--gateway', '连接 Connection Gateway，等待远程调试请求', false)
+      .option('--gateway-base-url <url>', 'Connection Gateway HTTP 地址')
+      .option('--gateway-auth-token <token>', 'Connection Gateway AUTH_TOKEN')
+      .option('--gateway-jwt-secret <secret>', 'Connection Gateway JWT_SECRET')
+      .option('--gateway-tcp-url <url>', 'Connection Gateway TCP 地址，如 tcp://host:port')
+      .option('--gateway-tcp-host <host>', 'Connection Gateway TCP host')
+      .option('--gateway-tcp-port <port>', 'Connection Gateway TCP port')
+      .option('--gateway-user-id <id>', 'debug session userId')
+      .option('--gateway-team-id <id>', 'debug session teamId')
+      .option('--gateway-source <source>', 'debug source，建议包含 user 维度')
+      .option('--gateway-subject <subject>', 'debug session subject')
+      .option('--gateway-token-ttl-ms <ms>', 'connection token TTL')
+      .action(async (entries: string[], opts: DebugCommandOptions) => {
+        await this.run(entries, opts);
       });
   }
 
-  public async run(entry: string, options: DebugCommandOptions): Promise<void> {
-    const entryDir = path.resolve(entry);
-    const uploadDir = path.resolve(
-      options.uploadDir ?? path.join(entryDir, '.fastgpt-plugin-debug/uploads')
+  public async run(entriesInput: string | string[], options: DebugCommandOptions): Promise<void> {
+    const entries = (Array.isArray(entriesInput) ? entriesInput : [entriesInput]).map((entry) =>
+      path.resolve(entry)
     );
-    const session = await loadDebugSession({
-      entryDir,
-      uploadDir
+    const isMultiEntry = entries.length > 1;
+
+    if (isMultiEntry && !options.gateway) {
+      throw new Error('多个插件同时调试需要使用 --gateway。');
+    }
+
+    if (isMultiEntry && options.run) {
+      throw new Error('--run 只支持单个插件入口。');
+    }
+
+    const sessions = [];
+    for (const [index, entryDir] of entries.entries()) {
+      sessions.push(
+        await loadDebugSession({
+          entryDir,
+          uploadDir: this.resolveUploadDir({
+            entryDir,
+            index,
+            total: entries.length,
+            uploadDir: options.uploadDir
+          })
+        })
+      );
+    }
+
+    sessions.forEach((session) => {
+      this.printSnapshot(session.snapshot, session.uploadDir);
     });
 
-    this.printSnapshot(session.snapshot, uploadDir);
+    const duplicatePluginIds = findDuplicateValues(
+      sessions.map((session) => session.snapshot.pluginId)
+    );
+    if (duplicatePluginIds.length > 0) {
+      throw new Error(`gateway pluginId 重复: ${duplicatePluginIds.join(', ')}`);
+    }
+
+    if (options.gateway) {
+      await this.runGatewaySession({
+        sessions,
+        options
+      });
+      return;
+    }
+
+    const [session] = sessions;
 
     if (!options.run) {
       return;
@@ -164,6 +231,108 @@ export class DebugCommand extends BaseCommand {
     return args.map(quoteShellArg).join(' ');
   }
 
+  private resolveGatewayOptions(
+    options: DebugCommandOptions,
+    snapshot: DebugPluginSnapshot
+  ): DebugGatewayClientOptions {
+    const userId = options.gatewayUserId ?? process.env.CONNECTION_GATEWAY_USER_ID ?? 'debug-user';
+    const tcpEndpoint = resolveGatewayTcpEndpoint(options);
+
+    return {
+      baseUrl:
+        options.gatewayBaseUrl ??
+        process.env.CONNECTION_GATEWAY_BASE_URL ??
+        'http://127.0.0.1:3010',
+      authToken:
+        options.gatewayAuthToken ??
+        process.env.CONNECTION_GATEWAY_AUTH_TOKEN ??
+        process.env.AUTH_TOKEN ??
+        'token',
+      jwtSecret: options.gatewayJwtSecret ?? process.env.JWT_SECRET ?? 'fastgpt-plugin-secret',
+      tcpHost: tcpEndpoint.host,
+      tcpPort: tcpEndpoint.port,
+      userId,
+      teamId: options.gatewayTeamId ?? process.env.CONNECTION_GATEWAY_TEAM_ID,
+      source: this.resolveGatewaySource(options, snapshot),
+      subject: options.gatewaySubject ?? process.env.CONNECTION_GATEWAY_SUBJECT,
+      tokenTtlMs: toPositiveInt(
+        options.gatewayTokenTtlMs ?? process.env.CONNECTION_GATEWAY_TOKEN_TTL_MS ?? '300000',
+        'gateway-token-ttl-ms'
+      )
+    };
+  }
+
+  private resolveGatewaySource(
+    options: DebugCommandOptions,
+    _snapshot: DebugPluginSnapshot
+  ): string {
+    const userId = options.gatewayUserId ?? process.env.CONNECTION_GATEWAY_USER_ID ?? 'debug-user';
+    const explicitSource = this.getExplicitGatewaySource(options);
+
+    if (explicitSource) {
+      return explicitSource;
+    }
+
+    return makeDefaultGatewaySource(userId);
+  }
+
+  private getExplicitGatewaySource(options: DebugCommandOptions): string | undefined {
+    return options.gatewaySource ?? process.env.CONNECTION_GATEWAY_SOURCE;
+  }
+
+  private async runGatewaySession({
+    sessions,
+    options
+  }: {
+    sessions: Array<{
+      runtime: Awaited<ReturnType<typeof loadDebugSession>>['runtime'];
+      snapshot: DebugPluginSnapshot;
+    }>;
+    options: DebugCommandOptions;
+  }): Promise<void> {
+    const source = this.resolveGatewaySource(options, sessions[0].snapshot);
+    const targets: DebugGatewayTarget[] = sessions.map((session) => ({
+      runtime: session.runtime,
+      snapshot: session.snapshot
+    }));
+    const gateway = await connectDebugGateway({
+      targets,
+      options: this.resolveGatewayOptions(options, sessions[0].snapshot),
+      onLog: (message) => logger.info(message)
+    });
+
+    targets.forEach((target) => {
+      logger.success(`远程调试已就绪: ${source} ${target.snapshot.pluginId}`);
+    });
+    logger.info(`已建立 1 个远程调试通道，挂载 ${targets.length} 个插件，按 Ctrl+C 停止。`);
+    await gateway.closed;
+  }
+
+  private resolveUploadDir({
+    entryDir,
+    index,
+    total,
+    uploadDir
+  }: {
+    entryDir: string;
+    index: number;
+    total: number;
+    uploadDir?: string;
+  }): string {
+    if (!uploadDir) {
+      return path.resolve(path.join(entryDir, '.fastgpt-plugin-debug/uploads'));
+    }
+
+    if (total === 1) {
+      return path.resolve(uploadDir);
+    }
+
+    return path.resolve(
+      uploadDir,
+      `${index + 1}-${sanitizePathSegment(path.basename(entryDir))}`
+    );
+  }
+
   private createInputExample(schema: Record<string, unknown>): unknown {
     if (Array.isArray(schema.enum) && schema.enum.length > 0) {
       return schema.enum[0];
@@ -250,4 +419,63 @@ function quoteShellArg(value: string): string {
   }
 
   return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function toPositiveInt(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} 必须是正整数。`);
+  }
+
+  return parsed;
+}
+
+function makeDefaultGatewaySource(userId: string): string {
+  return `debug:user:${userId}`;
+}
+
+function resolveGatewayTcpEndpoint(options: DebugCommandOptions): { host: string; port: number } {
+  const tcpUrl = options.gatewayTcpUrl ?? process.env.CONNECTION_GATEWAY_TCP_URL;
+
+  if (tcpUrl) {
+    const parsed = new URL(tcpUrl);
+    if (parsed.protocol !== 'tcp:') {
+      throw new Error('gateway-tcp-url 必须使用 tcp:// 协议。');
+    }
+    if (!parsed.hostname || !parsed.port) {
+      throw new Error('gateway-tcp-url 必须包含 host 和 port。');
+    }
+
+    return {
+      host: parsed.hostname,
+      port: toPositiveInt(parsed.port, 'gateway-tcp-url port')
+    };
+  }
+
+  return {
+    host: options.gatewayTcpHost ?? process.env.CONNECTION_GATEWAY_TCP_HOST ?? '127.0.0.1',
+    port: toPositiveInt(
+      options.gatewayTcpPort ?? process.env.CONNECTION_GATEWAY_TCP_PORT ?? '3011',
+      'gateway-tcp-port'
+    )
+  };
+}
+
+function findDuplicateValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+
+  values.forEach((value) => {
+    if (seen.has(value)) {
+      duplicates.add(value);
+      return;
+    }
+    seen.add(value);
+  });
+
+  return [...duplicates];
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_') || 'plugin';
 }

--- a/apps/cli/src/debug/gateway.ts
+++ b/apps/cli/src/debug/gateway.ts
@@ -1,0 +1,413 @@
+import { createHmac, randomUUID } from 'node:crypto';
+import net from 'node:net';
+
+import {
+  type ConnectionGatewayEnvelope,
+  type ConnectionGatewaySession,
+  ConnectionGatewaySessionSchema
+} from '@domain/value-objects/connection-gateway.vo';
+import {
+  CONNECTION_GATEWAY_BIND_CAPABILITY,
+  CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE,
+  CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+  ConnectionGatewayPluginDebugRequestPayloadSchema
+} from '@domain/value-objects/connection-gateway-debug.vo';
+import { ToolStreamMessageSchema, type ToolStreamMessageType } from '@domain/value-objects/tool.vo';
+
+import type { LocalDebugRuntime } from './runtime';
+import { type DebugPluginSnapshot, runDebugTool } from './session';
+
+const TOKEN_HEADER = {
+  alg: 'HS256',
+  typ: 'CGT'
+};
+
+export type DebugGatewayClientOptions = {
+  baseUrl: string;
+  authToken: string;
+  jwtSecret: string;
+  tcpHost: string;
+  tcpPort: number;
+  userId: string;
+  teamId?: string;
+  source?: string;
+  subject?: string;
+  tokenTtlMs: number;
+  reconnect?: boolean;
+};
+
+export type DebugGatewayTarget = {
+  runtime: LocalDebugRuntime;
+  snapshot: DebugPluginSnapshot;
+};
+
+export type DebugGatewayClient = {
+  session: ConnectionGatewaySession;
+  close(): void;
+  closed: Promise<void>;
+};
+
+export async function connectDebugGateway({
+  targets,
+  options,
+  onLog
+}: {
+  targets: DebugGatewayTarget[];
+  options: DebugGatewayClientOptions;
+  onLog?: (message: string) => void;
+}): Promise<DebugGatewayClient> {
+  if (targets.length === 0) {
+    throw new Error('Gateway debug targets cannot be empty');
+  }
+
+  const session = await createGatewaySession(targets, options);
+  const socket = await connectTcp(options.tcpHost, options.tcpPort);
+  const decoder = new ContentLengthJsonFrameDecoder(1024 * 1024 * 16);
+  const targetsByPluginId = new Map(targets.map((target) => [target.snapshot.pluginId, target]));
+  let closed = false;
+
+  const closedPromise = new Promise<void>((resolve, reject) => {
+    socket.once('close', () => {
+      closed = true;
+      resolve();
+    });
+    socket.once('error', reject);
+  });
+
+  socket.on('data', (chunk) => {
+    const frames = decoder.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    frames.forEach((envelope) => {
+      void handleGatewayEnvelope({
+        socket,
+        session,
+        targetsByPluginId,
+        envelope,
+        onLog
+      }).catch(async (error) => {
+        await sendEnvelope(socket, makeErrorEnvelope(session, envelope, error));
+      });
+    });
+  });
+
+  await sendEnvelope(socket, {
+    protocol: 'connection-gateway.v1',
+    sessionId: session.id,
+    generation: session.generation,
+    requestId: randomUUID(),
+    type: 'event',
+    consumerType: session.consumerType,
+    capability: CONNECTION_GATEWAY_BIND_CAPABILITY,
+    createdAt: Date.now(),
+    payload: {
+      kind: 'plugin-debug.bind',
+      sources: targets.map((target) => ({
+        source: session.sessionScope.source,
+        pluginId: target.snapshot.pluginId,
+        version: target.snapshot.version
+      }))
+    }
+  });
+  onLog?.(`已连接 Connection Gateway session: ${session.id}`);
+
+  return {
+    session,
+    close() {
+      if (!closed) {
+        socket.end();
+      }
+    },
+    closed: closedPromise
+  };
+}
+
+async function handleGatewayEnvelope({
+  socket,
+  session,
+  targetsByPluginId,
+  envelope,
+  onLog
+}: {
+  socket: net.Socket;
+  session: ConnectionGatewaySession;
+  targetsByPluginId: Map<string, DebugGatewayTarget>;
+  envelope: ConnectionGatewayEnvelope;
+  onLog?: (message: string) => void;
+}): Promise<void> {
+  if (envelope.type !== 'request') {
+    return;
+  }
+
+  const request = ConnectionGatewayPluginDebugRequestPayloadSchema.parse(envelope.payload);
+  const source = request.payload.source ?? session.sessionScope.source;
+  if (!source) {
+    throw new Error('Gateway debug request missing source');
+  }
+  const pluginId = request.payload.pluginId;
+  if (!pluginId) {
+    throw new Error('Gateway debug request missing pluginId');
+  }
+  const target = targetsByPluginId.get(pluginId);
+  if (!target) {
+    throw new Error(`Gateway debug target not found: ${source} ${pluginId}`);
+  }
+  onLog?.(`收到远程调试请求: ${source} ${pluginId} ${envelope.requestId ?? '-'}`);
+
+  await sendEnvelope(socket, {
+    protocol: 'connection-gateway.v1',
+    sessionId: session.id,
+    generation: session.generation,
+    requestId: requiredRequestId(envelope),
+    type: 'response',
+    consumerType: session.consumerType,
+    capability: CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+    traceId: envelope.traceId,
+    createdAt: Date.now(),
+    payload: {
+      kind: 'plugin-debug.accepted'
+    }
+  });
+
+  const result = await runDebugTool({
+    runtime: target.runtime,
+    snapshot: target.snapshot,
+    toolId: request.payload.childId,
+    input: request.payload.input,
+    secrets: request.payload.secrets,
+    systemVar: request.payload.systemVar
+  });
+
+  for (const message of result.streamMessages) {
+    await sendStreamChunk(socket, session, envelope, message);
+  }
+
+  await sendEnvelope(socket, {
+    protocol: 'connection-gateway.v1',
+    sessionId: session.id,
+    generation: session.generation,
+    requestId: requiredRequestId(envelope),
+    type: 'stream',
+    consumerType: session.consumerType,
+    capability: CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+    traceId: envelope.traceId,
+    createdAt: Date.now(),
+    payload: {
+      kind: 'plugin-debug.stream',
+      event: 'end'
+    }
+  });
+}
+
+async function sendStreamChunk(
+  socket: net.Socket,
+  session: ConnectionGatewaySession,
+  request: ConnectionGatewayEnvelope,
+  message: ToolStreamMessageType
+): Promise<void> {
+  await sendEnvelope(socket, {
+    protocol: 'connection-gateway.v1',
+    sessionId: session.id,
+    generation: session.generation,
+    requestId: requiredRequestId(request),
+    type: 'stream',
+    consumerType: session.consumerType,
+    capability: CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+    traceId: request.traceId,
+    createdAt: Date.now(),
+    payload: {
+      kind: 'plugin-debug.stream',
+      event: 'chunk',
+      data: ToolStreamMessageSchema.parse(message)
+    }
+  });
+}
+
+function makeErrorEnvelope(
+  session: ConnectionGatewaySession,
+  request: ConnectionGatewayEnvelope,
+  error: unknown
+): ConnectionGatewayEnvelope {
+  return {
+    protocol: 'connection-gateway.v1',
+    sessionId: session.id,
+    generation: session.generation,
+    requestId: request.requestId,
+    type: 'stream',
+    consumerType: session.consumerType,
+    capability: CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+    traceId: request.traceId,
+    createdAt: Date.now(),
+    payload: {
+      kind: 'plugin-debug.stream',
+      event: 'error',
+      message: error instanceof Error ? error.message : String(error)
+    }
+  };
+}
+
+async function createGatewaySession(
+  targets: DebugGatewayTarget[],
+  options: DebugGatewayClientOptions
+): Promise<ConnectionGatewaySession> {
+  const now = Date.now();
+  const source = options.source ?? makeDefaultDebugSource(options.userId);
+  const claims = {
+    consumerType: CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE,
+    subject: options.subject ?? `user:${options.userId}`,
+    sessionScope: {
+      userId: options.userId,
+      ...(options.teamId ? { teamId: options.teamId } : {}),
+      source
+    },
+    transport: 'tcp' as const,
+    capabilities: [CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY],
+    issuedAt: now,
+    expiresAt: now + options.tokenTtlMs,
+    nonce: randomUUID()
+  };
+  const token = signConnectionToken(claims, options.jwtSecret);
+  const response = await fetch(`${normalizeBaseUrl(options.baseUrl)}/internal/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${options.authToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      token,
+      transport: 'tcp',
+      metadata: {
+        pluginDebug: {
+          targets: targets.map((target) => ({
+            source,
+            pluginId: target.snapshot.pluginId,
+            version: target.snapshot.version,
+            name: target.snapshot.name,
+            description: target.snapshot.description,
+            toolDescription: target.snapshot.toolDescription,
+            author: target.snapshot.author,
+            tags: target.snapshot.tags,
+            permissions: target.snapshot.permissions,
+            secretSchema: target.snapshot.secretSchema,
+            isToolSet: target.snapshot.isToolSet,
+            tools: target.snapshot.tools
+          }))
+        }
+      }
+    })
+  });
+  const payload = await parseJsonResponse(response);
+  const session = payload.data?.session;
+
+  return ConnectionGatewaySessionSchema.parse(session);
+}
+
+function makeDefaultDebugSource(userId: string): string {
+  return `debug:user:${userId}`;
+}
+
+function signConnectionToken(claims: unknown, secret: string): string {
+  const header = encodeBase64Url(JSON.stringify(TOKEN_HEADER));
+  const payload = encodeBase64Url(JSON.stringify(claims));
+  const signature = encodeBase64Url(createHmac('sha256', secret).update(`${header}.${payload}`).digest());
+
+  return `${header}.${payload}.${signature}`;
+}
+
+function encodeBase64Url(value: string | Buffer): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+async function parseJsonResponse(response: Response): Promise<Record<string, any>> {
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : {};
+
+  if (!response.ok) {
+    throw new Error(`Gateway request failed: ${response.status} ${response.statusText}\n${text}`);
+  }
+
+  return payload;
+}
+
+async function connectTcp(host: string, port: number): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, host, () => {
+      socket.off('error', reject);
+      resolve(socket);
+    });
+    socket.once('error', reject);
+  });
+}
+
+async function sendEnvelope(socket: net.Socket, envelope: ConnectionGatewayEnvelope): Promise<void> {
+  const frame = encodeContentLengthJsonFrame(envelope);
+  await new Promise<void>((resolve, reject) => {
+    socket.write(frame, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function encodeContentLengthJsonFrame(envelope: ConnectionGatewayEnvelope): Buffer {
+  const body = Buffer.from(JSON.stringify(envelope), 'utf8');
+  return Buffer.concat([
+    Buffer.from(`Content-Length: ${body.byteLength}\r\n\r\n`, 'utf8'),
+    body
+  ]);
+}
+
+class ContentLengthJsonFrameDecoder {
+  private buffer = Buffer.alloc(0);
+
+  constructor(private readonly maxFrameBytes: number) {}
+
+  push(chunk: Buffer): ConnectionGatewayEnvelope[] {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const frames: ConnectionGatewayEnvelope[] = [];
+
+    while (true) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (headerEnd < 0) {
+        return frames;
+      }
+
+      const header = this.buffer.subarray(0, headerEnd).toString('utf8');
+      const contentLength = Number(
+        header
+          .split(/\r?\n/)
+          .find((line) => line.toLowerCase().startsWith('content-length:'))
+          ?.split(':')[1]
+          ?.trim()
+      );
+      if (!Number.isSafeInteger(contentLength) || contentLength < 0) {
+        throw new Error('Invalid Content-Length frame');
+      }
+      if (contentLength > this.maxFrameBytes) {
+        throw new Error(`Gateway frame is too large: ${contentLength}`);
+      }
+
+      const bodyStart = headerEnd + 4;
+      const bodyEnd = bodyStart + contentLength;
+      if (this.buffer.byteLength < bodyEnd) {
+        return frames;
+      }
+
+      frames.push(JSON.parse(this.buffer.subarray(bodyStart, bodyEnd).toString('utf8')));
+      this.buffer = this.buffer.subarray(bodyEnd);
+    }
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function requiredRequestId(envelope: ConnectionGatewayEnvelope): string {
+  if (!envelope.requestId) {
+    throw new Error('Gateway request envelope missing requestId');
+  }
+
+  return envelope.requestId;
+}

--- a/apps/connection-gateway/.env.template
+++ b/apps/connection-gateway/.env.template
@@ -1,0 +1,64 @@
+# ================ 系统 =====================
+NODE_ENV=production
+
+# ================ HTTP / TCP 服务 =====================
+# HTTP API 端口，用于 /health、/metrics、/internal/*。
+CONNECTION_GATEWAY_PORT=3011
+# TCP 长连接端口，用于本地 CLI / 其他消费者建立调试或长链接通道。
+CONNECTION_GATEWAY_TCP_PORT=3012
+# 外部访问地址可以和监听端口不同，尤其在 k8s / LB / Sealos 中 HTTP 与 TCP 常使用不同域名。
+# plugin-server 使用 HTTP 地址访问 gateway internal API。
+CONNECTION_GATEWAY_BASE_URL=https://connection-gateway.example.com
+# CLI / 外部长连接消费者使用 TCP 地址连接 gateway。
+CONNECTION_GATEWAY_TCP_URL=tcp://connection-gateway-tcp.example.com:3012
+# 多节点部署建议使用 Pod UID / container id / instance id；为空时进程会生成 opaque id。
+CONNECTION_GATEWAY_NODE_ID=
+
+# ================ 认证 =====================
+# Gateway internal HTTP API Bearer token；plugin-server/CLI 通过 CONNECTION_GATEWAY_AUTH_TOKEN 或 --gateway-auth-token 使用它。
+# 生产环境必须替换为至少 32 位的强随机值。
+AUTH_TOKEN=replace-with-strong-token-at-least-32-chars
+# Connection token HMAC secret。当前 PR2 CLI 临时 bootstrap 阶段需要 plugin-server、CLI 和 gateway 保持一致。
+JWT_SECRET=replace-with-strong-jwt-secret
+
+# ================ Redis =====================
+# Gateway session registry 和 mailbox 依赖 Redis；多节点部署必须使用同一个 Redis。
+REDIS_URL=redis://default:password@localhost:6379/0
+
+# ================ Session / Mailbox =====================
+# Session TTL(ms)。本地 CLI 调试通道会按 owner lease 续租。
+CONNECTION_GATEWAY_SESSION_TTL_MS=60000
+# Owner lease TTL(ms)。
+CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS=15000
+# 单个 session mailbox 最大长度。
+CONNECTION_GATEWAY_MAILBOX_MAXLEN=1000
+# mailbox 阻塞读取时间(ms)。
+CONNECTION_GATEWAY_MAILBOX_BLOCK_MS=5000
+
+# ================ 资源限制 =====================
+CONNECTION_GATEWAY_MAX_CONNECTIONS=5000
+CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT=5
+CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION=50
+# 单个 envelope 最大字节数。
+CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES=1048576
+# 慢消费者缓冲阈值(Bytes)。
+CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES=8388608
+
+# ================ 日志 =====================
+LOG_ENABLE_CONSOLE=true
+# 控制台日志等级: "trace" | "debug" | "info" | "warning" | "error" | "fatal"
+LOG_CONSOLE_LEVEL=info
+LOG_ENABLE_OTEL=false
+LOG_OTEL_LEVEL=info
+LOG_OTEL_SERVICE_NAME=fastgpt-connection-gateway
+LOG_OTEL_URL=http://localhost:4318/v1/logs
+
+# ================ 指标 =====================
+METRICS_ENABLE_OTEL=false
+METRICS_OTEL_SERVICE_NAME=fastgpt-connection-gateway
+METRICS_OTEL_URL=http://localhost:4318/v1/metrics
+METRICS_EXPORT_INTERVAL_MS=30000
+METRICS_EXPORT_TIMEOUT_MS=10000
+METRICS_INCLUDE_HOSTNAME=true
+SERVICE_INSTANCE_ID=
+DEPLOYMENT_ENVIRONMENT=

--- a/apps/connection-gateway/Dockerfile
+++ b/apps/connection-gateway/Dockerfile
@@ -78,10 +78,10 @@ COPY --from=prod-deps --chown=fastgpt:fastgpt /app/apps/connection-gateway/packa
 COPY --from=builder --chown=fastgpt:fastgpt /app/apps/connection-gateway/dist ./dist
 
 ENV NODE_ENV=production
-ENV CONNECTION_GATEWAY_PORT=3010
-ENV CONNECTION_GATEWAY_TCP_PORT=3011
+ENV CONNECTION_GATEWAY_PORT=3000
+ENV CONNECTION_GATEWAY_TCP_PORT=3001
 
-EXPOSE 3010 3011
+EXPOSE 3000 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD curl -fsS "http://127.0.0.1:${CONNECTION_GATEWAY_PORT}/health" >/dev/null || exit 1

--- a/apps/connection-gateway/main.ts
+++ b/apps/connection-gateway/main.ts
@@ -2,7 +2,7 @@ import { inspect } from 'node:util';
 
 import { serve, type ServerType } from '@hono/node-server';
 
-import { env } from '@infrastructure/env';
+import { gatewayEnv } from '@infrastructure/env';
 import { configureLogger, destroyLogger, getLogger, root } from '@infrastructure/logger';
 import { configureMetrics, destroyMetrics } from '@infrastructure/metrics';
 import { configureProxy } from '@infrastructure/utils/proxy';
@@ -11,19 +11,15 @@ import { getErrText } from '@shared/utils/err';
 import { makeConnectionGatewayDeps } from './src/deps';
 import { createConnectionGatewayApp } from './src/routes';
 
-await configureLogger();
-await configureMetrics();
-
 const logger = getLogger(root);
-const deps = makeConnectionGatewayDeps();
-const app = createConnectionGatewayApp(deps);
 
 let server: ServerType | null = null;
 let shuttingDown = false;
+let deps: ReturnType<typeof makeConnectionGatewayDeps> | null = null;
 
-async function prepare() {
-  configureProxy();
-  await deps.tcpTransport.start();
+async function prepare(activeDeps: ReturnType<typeof makeConnectionGatewayDeps>) {
+  configureProxy(gatewayEnv);
+  await activeDeps.tcpTransport.start();
 }
 
 async function closeServer(): Promise<void> {
@@ -52,9 +48,10 @@ function shutdown() {
     let exitCode = 0;
 
     try {
-      await deps.tcpTransport.stop();
+      await deps?.tcpTransport.stop();
+      await deps?.mailbox.disconnect?.();
       await closeServer();
-      await deps.redisClient.disconnect();
+      await deps?.redisClient.disconnect();
       await destroyMetrics();
     } catch (error) {
       exitCode = 1;
@@ -67,8 +64,13 @@ function shutdown() {
 }
 
 async function main() {
+  await configureLogger(gatewayEnv);
+  await configureMetrics(gatewayEnv);
+  deps = makeConnectionGatewayDeps();
+  const app = createConnectionGatewayApp(deps);
+
   try {
-    await prepare();
+    await prepare(deps);
   } catch (error) {
     const errorMessage = getErrText(error, 'Unknown connection gateway startup error');
 
@@ -84,11 +86,11 @@ async function main() {
   server = serve(
     {
       fetch: app.fetch,
-      port: env.CONNECTION_GATEWAY_PORT
+      port: gatewayEnv.CONNECTION_GATEWAY_PORT
     },
     (info) => {
       logger.info(`Connection Gateway HTTP server is listening at http://0.0.0.0:${info.port}`);
-      logger.info(`Connection Gateway TCP server is listening at tcp://0.0.0.0:${env.CONNECTION_GATEWAY_TCP_PORT}`);
+      logger.info(`Connection Gateway TCP server is listening at tcp://0.0.0.0:${gatewayEnv.CONNECTION_GATEWAY_TCP_PORT}`);
     }
   );
 }

--- a/apps/connection-gateway/src/deps.ts
+++ b/apps/connection-gateway/src/deps.ts
@@ -1,36 +1,38 @@
 import { ConnectionGatewayResourceLimitsSchema } from '@domain/value-objects/connection-gateway.vo';
-import { HmacConnectionGatewayToken } from '@infrastructure/connection-gateway/token';
+import { CONNECTION_GATEWAY_BIND_CAPABILITY } from '@domain/value-objects/connection-gateway-debug.vo';
 import { RedisConnectionGatewayMailbox } from '@infrastructure/connection-gateway/mailbox';
 import { InMemoryConnectionGatewayMetrics } from '@infrastructure/connection-gateway/metrics';
 import { ConnectionGatewayResourceLimiter } from '@infrastructure/connection-gateway/resource-limiter';
 import { ConnectionGatewayService } from '@infrastructure/connection-gateway/service';
 import { RedisConnectionGatewaySessionRegistry } from '@infrastructure/connection-gateway/session-registry';
+import { HmacConnectionGatewayToken } from '@infrastructure/connection-gateway/token';
 import { TcpConnectionGatewayTransport } from '@infrastructure/connection-gateway/transports/tcp-transport';
-import { env } from '@infrastructure/env';
+import type { ConnectionGatewayTransportConnection } from '@infrastructure/connection-gateway/transports/transport';
+import { gatewayEnv } from '@infrastructure/env';
 import { getLogger, root } from '@infrastructure/logger';
 import { getServiceInstanceId } from '@infrastructure/metrics';
 import { RedisClient } from '@infrastructure/redis/redis-client';
 
 export function makeConnectionGatewayDeps() {
   const logger = getLogger(root);
-  const redisClient = RedisClient.getInstance();
-  const nodeId = env.CONNECTION_GATEWAY_NODE_ID ?? getServiceInstanceId();
+  const redisClient = RedisClient.create({ redisUrl: gatewayEnv.REDIS_URL });
+  const nodeId = gatewayEnv.CONNECTION_GATEWAY_NODE_ID ?? getServiceInstanceId();
   const limits = ConnectionGatewayResourceLimitsSchema.parse({
-    maxConnections: env.CONNECTION_GATEWAY_MAX_CONNECTIONS,
-    maxSessionsPerSubject: env.CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT,
-    maxInFlightPerSession: env.CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION,
-    maxEnvelopeBytes: env.CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES,
-    slowConsumerBufferBytes: env.CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES
+    maxConnections: gatewayEnv.CONNECTION_GATEWAY_MAX_CONNECTIONS,
+    maxSessionsPerSubject: gatewayEnv.CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT,
+    maxInFlightPerSession: gatewayEnv.CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION,
+    maxEnvelopeBytes: gatewayEnv.CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES,
+    slowConsumerBufferBytes: gatewayEnv.CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES
   });
   const metrics = new InMemoryConnectionGatewayMetrics(nodeId, limits);
   const limiter = new ConnectionGatewayResourceLimiter(limits);
-  const tokenVerifier = new HmacConnectionGatewayToken(env.JWT_SECRET);
+  const tokenVerifier = new HmacConnectionGatewayToken(gatewayEnv.JWT_SECRET);
   const sessionRegistry = new RedisConnectionGatewaySessionRegistry(
     redisClient.getClient,
-    env.CONNECTION_GATEWAY_SESSION_TTL_MS
+    gatewayEnv.CONNECTION_GATEWAY_SESSION_TTL_MS
   );
   const mailbox = new RedisConnectionGatewayMailbox(redisClient.getClient, {
-    maxLen: env.CONNECTION_GATEWAY_MAILBOX_MAXLEN,
+    maxLen: gatewayEnv.CONNECTION_GATEWAY_MAILBOX_MAXLEN,
     metrics
   });
   const service = new ConnectionGatewayService({
@@ -41,20 +43,53 @@ export function makeConnectionGatewayDeps() {
     limiter,
     options: {
       nodeId,
-      sessionTtlMs: env.CONNECTION_GATEWAY_SESSION_TTL_MS,
-      ownerLeaseTtlMs: env.CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS,
-      mailboxMaxLen: env.CONNECTION_GATEWAY_MAILBOX_MAXLEN
+      sessionTtlMs: gatewayEnv.CONNECTION_GATEWAY_SESSION_TTL_MS,
+      ownerLeaseTtlMs: gatewayEnv.CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS,
+      mailboxBlockMs: gatewayEnv.CONNECTION_GATEWAY_MAILBOX_BLOCK_MS,
+      mailboxMaxLen: gatewayEnv.CONNECTION_GATEWAY_MAILBOX_MAXLEN
     }
   });
+  const boundConnections = new Map<string, { sessionId: string; closed: boolean }>();
   const tcpTransport = new TcpConnectionGatewayTransport({
-    port: env.CONNECTION_GATEWAY_TCP_PORT,
-    maxFrameBytes: env.CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES,
+    port: gatewayEnv.CONNECTION_GATEWAY_TCP_PORT,
+    maxFrameBytes: gatewayEnv.CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES,
     limiter,
     handlers: {
       onConnection: () => metrics.recordConnectionOpened(),
-      onClose: () => metrics.recordConnectionClosed(),
-      onEnvelope: async (_connection, envelope) => {
-        await service.publishRequest({
+      onClose: (connection) => {
+        metrics.recordConnectionClosed();
+        const binding = boundConnections.get(connection.id);
+        if (binding) {
+          binding.closed = true;
+          boundConnections.delete(connection.id);
+        }
+      },
+      onEnvelope: async (connection, envelope) => {
+        if (envelope.type === 'event' && envelope.capability === CONNECTION_GATEWAY_BIND_CAPABILITY) {
+          const session = await service.bindSession({
+            sessionId: envelope.sessionId,
+            envelope
+          });
+          const binding = { sessionId: session.id, closed: false };
+          boundConnections.set(connection.id, binding);
+          void pumpSessionMailbox({
+            service,
+            connection,
+            binding,
+            logger
+          });
+          return;
+        }
+
+        if (envelope.type === 'request') {
+          await service.publishRequest({
+            sessionId: envelope.sessionId,
+            envelope
+          });
+          return;
+        }
+
+        await service.publishResponse({
           sessionId: envelope.sessionId,
           envelope
         });
@@ -71,6 +106,7 @@ export function makeConnectionGatewayDeps() {
 
   return {
     redisClient,
+    mailbox,
     service,
     tcpTransport,
     metrics,
@@ -79,3 +115,51 @@ export function makeConnectionGatewayDeps() {
 }
 
 export type ConnectionGatewayDeps = ReturnType<typeof makeConnectionGatewayDeps>;
+
+async function pumpSessionMailbox({
+  service,
+  connection,
+  binding,
+  logger
+}: {
+  service: ConnectionGatewayService;
+  connection: ConnectionGatewayTransportConnection;
+  binding: { sessionId: string; closed: boolean };
+  logger: ReturnType<typeof getLogger>;
+}) {
+  let afterId: string | undefined = '0-0';
+
+  while (!binding.closed) {
+    try {
+      await service.renewOwnerLease(binding.sessionId);
+      const messages = await service.readSessionRequests({
+        sessionId: binding.sessionId,
+        afterId,
+        count: 10
+      });
+
+      if (messages.length === 0) {
+        continue;
+      }
+
+      afterId = messages[messages.length - 1].id;
+
+      for (const message of messages) {
+        await connection.send(message.envelope);
+      }
+
+      await service.ackSessionRequests(
+        binding.sessionId,
+        messages.map((message) => message.id)
+      );
+    } catch (error) {
+      logger.warn('Connection Gateway TCP mailbox pump failed', {
+        connectionId: connection.id,
+        sessionId: binding.sessionId,
+        error
+      });
+      connection.close(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+  }
+}

--- a/apps/connection-gateway/src/routes.ts
+++ b/apps/connection-gateway/src/routes.ts
@@ -5,7 +5,8 @@ import {
   ConnectionGatewayMetricsDTOSchema,
   ConnectionGatewayRequestAcceptedDTOSchema,
   ConnectionGatewayRequestDTOSchema,
-  ConnectionGatewaySessionStatusViewDTOSchema
+  ConnectionGatewaySessionStatusViewDTOSchema,
+  ConnectionGatewayStreamRequestDTOSchema
 } from '@interface-adapter/contracts/dto/connection-gateway.dto';
 import { cors } from 'hono/cors';
 import { requestId } from 'hono/request-id';
@@ -13,7 +14,8 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import z from 'zod';
 
 import { RegisteredError } from '@domain/value-objects/error.vo';
-import { bearerHonoAuthMiddleware } from '@infrastructure/hono/middleware/auth';
+import { gatewayEnv } from '@infrastructure/env';
+import { createBearerHonoAuthMiddleware } from '@infrastructure/hono/middleware/auth';
 import { loggerHonoMiddleware } from '@infrastructure/hono/middleware/logger';
 import { createOpenAPIHono, createRoute, R } from '@infrastructure/hono/utils/response';
 
@@ -33,8 +35,9 @@ export function createConnectionGatewayApp(deps: Pick<ConnectionGatewayDeps, 'se
   );
   app.use('*', requestId());
   app.use('*', loggerHonoMiddleware);
-  app.use('/metrics', bearerHonoAuthMiddleware);
-  app.use('/internal/*', bearerHonoAuthMiddleware);
+  const gatewayAuthMiddleware = createBearerHonoAuthMiddleware(gatewayEnv.AUTH_TOKEN);
+  app.use('/metrics', gatewayAuthMiddleware);
+  app.use('/internal/*', gatewayAuthMiddleware);
 
   app.doc31('/openapi.json', {
     openapi: '3.1.0',
@@ -78,6 +81,29 @@ export function createConnectionGatewayApp(deps: Pick<ConnectionGatewayDeps, 'se
   app.openapi(
     createRoute({
       method: 'get',
+      path: '/internal/sessions/by-source/:source/status',
+      summary: 'Get latest gateway session status by source',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      responses: {
+        200: jsonResponse(ConnectionGatewaySessionStatusViewDTOSchema),
+        404: errorResponse()
+      }
+    }),
+    async (c) => {
+      const source = decodeURIComponent(requiredParam(c.req.param('source')));
+      const status = await deps.service.getLatestStatusBySource(source);
+      if (!status.session) {
+        return R.fail(c, 404, 'Gateway session not found');
+      }
+
+      return R.success(c, status);
+    }
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'get',
       path: '/metrics',
       summary: 'Gateway metrics',
       tags: ['connection-gateway'],
@@ -87,6 +113,70 @@ export function createConnectionGatewayApp(deps: Pick<ConnectionGatewayDeps, 'se
       }
     }),
     (c) => R.success(c, deps.service.metrics())
+  );
+
+  app.openapi(
+    createRoute({
+      method: 'post',
+      path: '/internal/sessions/:sessionId/requests:stream',
+      summary: 'Publish a request envelope and stream response envelopes',
+      tags: ['connection-gateway'],
+      security: [{ bearerAuth: [] }],
+      request: jsonRequest(ConnectionGatewayStreamRequestDTOSchema),
+      responses: {
+        200: {
+          description: 'NDJSON response envelope stream',
+          content: {
+            'application/x-ndjson': {
+              schema: z.string()
+            }
+          }
+        },
+        400: errorResponse(),
+        403: errorResponse(),
+        404: errorResponse(),
+        409: errorResponse(),
+        413: errorResponse(),
+        429: errorResponse()
+      }
+    }),
+    async (c) => {
+      try {
+        const body = ConnectionGatewayStreamRequestDTOSchema.parse(c.req.valid('json'));
+        const { responses } = await deps.service.publishRequestAndWait({
+          sessionId: requiredParam(c.req.param('sessionId')),
+          envelope: body.envelope,
+          timeoutMs: body.timeoutMs
+        });
+        const encoder = new TextEncoder();
+
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start: async (controller) => {
+              try {
+                for await (const envelope of responses) {
+                  controller.enqueue(encoder.encode(`${JSON.stringify(envelope)}\n`));
+                }
+              } catch (error) {
+                controller.error(error);
+              } finally {
+                controller.close();
+              }
+            }
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/x-ndjson; charset=utf-8',
+              'Cache-Control': 'no-cache, no-transform',
+              Connection: 'keep-alive'
+            }
+          }
+        );
+      } catch (error) {
+        return R.fail(c, statusFromError(error), normalizeError(error));
+      }
+    }
   );
 
   app.openapi(

--- a/apps/server/.env.template
+++ b/apps/server/.env.template
@@ -2,10 +2,20 @@
 NODE_ENV=development
 PORT=3000
 AUTH_TOKEN=94d2c3e42bab07e9a6ea55ae790d493ba0e10e8a20052242ed0cb6298ebcdb4a
+# Connection token HMAC secret；当前 PR2 CLI 临时 bootstrap 阶段需要 plugin-server、CLI 和 gateway 保持一致。
 JWT_SECRET=fastgpt-plugin-secret
 # 最大 API 请求体大小(MB)
 MAX_API_SIZE=10
 FASTGPT_BASE_URL=http://localhost:3000
+
+# ================ Connection Gateway =====================
+# plugin-server 通过 HTTP internal API 访问 gateway；TCP 连接地址由 CLI / 外部长连接消费者配置。
+CONNECTION_GATEWAY_BASE_URL=http://localhost:3010
+# 调用 connection-gateway internal API 的 Bearer token；生产环境建议显式配置，本地/远程 gateway token 不同时必须显式配置。
+CONNECTION_GATEWAY_AUTH_TOKEN=replace-with-connection-gateway-auth-token
+# Debug runtime 等待本地调试插件响应的超时时间(ms)。
+CONNECTION_GATEWAY_DEBUG_REQUEST_TIMEOUT_MS=120000
+
 # 工具网络请求，最大请求和响应体
 SERVICE_REQUEST_MAX_CONTENT_LENGTH=10
 # 禁用缓存

--- a/apps/server/main.ts
+++ b/apps/server/main.ts
@@ -2,7 +2,7 @@ import { inspect } from 'node:util';
 
 import { serve, type ServerType } from '@hono/node-server';
 
-import { env } from '@infrastructure/env';
+import { serverEnv } from '@infrastructure/env';
 import { app } from '@infrastructure/hono/app';
 import { configureLogger, destroyLogger, getLogger, mod, root } from '@infrastructure/logger';
 import { configureMetrics, destroyMetrics } from '@infrastructure/metrics';
@@ -20,7 +20,7 @@ import { makeWorkflowRoute } from './src/routes/workflow.route';
 await configureLogger(); // setup logger
 await configureMetrics(); // setup metrics
 const logger = getLogger(root);
-logger.debug(env);
+logger.debug(serverEnv);
 
 const modelRoute = makeModelRoute(deps);
 const pluginRoute = makePluginRoute(deps);
@@ -109,7 +109,7 @@ async function main() {
   server = serve(
     {
       fetch: app.fetch,
-      port: env.PORT
+      port: serverEnv.PORT
     },
     (info) => {
       logger.info(`Server is listening at http://0.0.0.0:${info.port}`);

--- a/apps/server/src/deps.ts
+++ b/apps/server/src/deps.ts
@@ -1,8 +1,11 @@
-import { env } from '@infrastructure/env';
+import { serverEnv } from '@infrastructure/env';
 import { LocalFileStorageRepo } from '@infrastructure/file-storage/local-file-storage.repo';
 import { RemoteFileStorageRepo } from '@infrastructure/file-storage/remote-file-storage.repo';
 import { FileTTLManager } from '@infrastructure/file-ttl/file-ttl.impl';
+import { DebugPluginRepoOverlay } from '@infrastructure/plugin/debug-plugin.repo';
 import { PluginRepo } from '@infrastructure/plugin/plugin.repo';
+import { CompositePluginRuntimeManager } from '@infrastructure/plugin/plugin-runtime/composite-runtime.manager';
+import { ConnectionGatewayDebugRuntimeManager } from '@infrastructure/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver';
 import { LocalPoolPluginRuntimeManager } from '@infrastructure/plugin/plugin-runtime/drivers/local-pool/local-pool-runtime.driver';
 import { ToolManager } from '@infrastructure/plugin/tool.impl';
 import { PluginPKFFileResolver } from '@infrastructure/plugin/utils/plugin-pkg-file-resolver.impl';
@@ -33,12 +36,18 @@ export const fileTTLManager = new FileTTLManager({
   publicRemoteFileStorageRepo
 });
 
-export const pluginRepo = PluginRepo.getInstance({
+const mongoPluginRepo = PluginRepo.getInstance({
   localFileStorageRepo,
   mongoClient,
   privateRemoteFileStorageRepo,
   publicRemoteFileStorageRepo,
   fileTTLManager
+});
+
+export const pluginRepo = new DebugPluginRepoOverlay({
+  fallback: mongoPluginRepo,
+  gatewayBaseUrl: serverEnv.CONNECTION_GATEWAY_BASE_URL,
+  authToken: serverEnv.CONNECTION_GATEWAY_AUTH_TOKEN
 });
 
 export const pluginPKGFileResolver = new PluginPKFFileResolver({
@@ -54,13 +63,22 @@ const localPoolPluginRuntimeManager = LocalPoolPluginRuntimeManager.getInstance(
   mongoClient,
   redisClient
 });
+const connectionGatewayDebugRuntimeManager = new ConnectionGatewayDebugRuntimeManager({
+  baseUrl: serverEnv.CONNECTION_GATEWAY_BASE_URL,
+  authToken: serverEnv.CONNECTION_GATEWAY_AUTH_TOKEN,
+  requestTimeoutMs: serverEnv.CONNECTION_GATEWAY_DEBUG_REQUEST_TIMEOUT_MS,
+  sourceForUser: ({ userId }) => `debug:user:${userId}`
+});
 
-export const pluginRuntimeManager = localPoolPluginRuntimeManager;
+export const pluginRuntimeManager = new CompositePluginRuntimeManager({
+  primary: localPoolPluginRuntimeManager,
+  debug: connectionGatewayDebugRuntimeManager
+});
 
 export const toolManager = ToolManager.getInstance({
   pluginRepo,
   pluginRuntimeManager,
-  fastgptBaseUrl: env.FASTGPT_BASE_URL
+  fastgptBaseUrl: serverEnv.FASTGPT_BASE_URL
 });
 
 const deps = {

--- a/packages/domain/src/ports/connection-gateway/mailbox.port.ts
+++ b/packages/domain/src/ports/connection-gateway/mailbox.port.ts
@@ -19,4 +19,5 @@ export interface ConnectionGatewayMailboxPort {
   trim(sessionId: string, maxLen: number): Promise<void>;
   expire(sessionId: string, ttlMs: number): Promise<void>;
   lag(sessionId: string): Promise<number>;
+  disconnect?(): Promise<void>;
 }

--- a/packages/domain/src/ports/connection-gateway/session-registry.port.ts
+++ b/packages/domain/src/ports/connection-gateway/session-registry.port.ts
@@ -23,6 +23,7 @@ export interface ConnectionGatewaySessionRegistryPort {
   create(input: CreateConnectionGatewaySessionInput): Promise<ConnectionGatewaySession>;
   get(sessionId: string): Promise<ConnectionGatewaySession | null>;
   listBySubject(subject: string): Promise<ConnectionGatewaySession[]>;
+  listBySource(source: string): Promise<ConnectionGatewaySession[]>;
   renewOwnerLease(input: RenewConnectionGatewayOwnerLeaseInput): Promise<boolean>;
   updateStatus(input: {
     sessionId: string;

--- a/packages/domain/src/ports/plugin/plugin-runtime-manager.port.ts
+++ b/packages/domain/src/ports/plugin/plugin-runtime-manager.port.ts
@@ -16,6 +16,10 @@ export type PluginRuntimeInvokeOptions = {
   invoke?: InvokePort;
   timeout?: number;
   priority?: number;
+  debug?: {
+    userId: string;
+    source?: string;
+  };
 };
 
 /**

--- a/packages/domain/src/value-objects/connection-gateway-debug.vo.ts
+++ b/packages/domain/src/value-objects/connection-gateway-debug.vo.ts
@@ -1,0 +1,59 @@
+import z from 'zod';
+
+import { SystemVarSchema } from './system-var.vo';
+import { ToolStreamMessageSchema } from './tool.vo';
+
+export const CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE = 'plugin-debug';
+export const CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY = 'invoke';
+export const CONNECTION_GATEWAY_BIND_CAPABILITY = 'gateway.bind';
+
+export const ConnectionGatewayPluginDebugRequestPayloadSchema = z.object({
+  kind: z.literal('plugin-debug.run'),
+  eventName: z.literal('run'),
+  payload: z.object({
+    pluginId: z.string().min(1).optional(),
+    input: z.record(z.string(), z.unknown()),
+    secrets: z.record(z.string(), z.unknown()).optional(),
+    systemVar: SystemVarSchema,
+    source: z.string().optional(),
+    childId: z.string().optional()
+  })
+});
+export type ConnectionGatewayPluginDebugRequestPayload = z.infer<
+  typeof ConnectionGatewayPluginDebugRequestPayloadSchema
+>;
+
+export const ConnectionGatewayPluginDebugResponsePayloadSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('plugin-debug.accepted')
+  }),
+  z.object({
+    kind: z.literal('plugin-debug.error'),
+    message: z.string(),
+    code: z.string().optional(),
+    data: z.unknown().optional()
+  })
+]);
+export type ConnectionGatewayPluginDebugResponsePayload = z.infer<
+  typeof ConnectionGatewayPluginDebugResponsePayloadSchema
+>;
+
+export const ConnectionGatewayPluginDebugStreamPayloadSchema = z.discriminatedUnion('event', [
+  z.object({
+    kind: z.literal('plugin-debug.stream'),
+    event: z.literal('chunk'),
+    data: ToolStreamMessageSchema
+  }),
+  z.object({
+    kind: z.literal('plugin-debug.stream'),
+    event: z.literal('end')
+  }),
+  z.object({
+    kind: z.literal('plugin-debug.stream'),
+    event: z.literal('error'),
+    message: z.string()
+  })
+]);
+export type ConnectionGatewayPluginDebugStreamPayload = z.infer<
+  typeof ConnectionGatewayPluginDebugStreamPayloadSchema
+>;

--- a/packages/domain/src/value-objects/connection-gateway.vo.ts
+++ b/packages/domain/src/value-objects/connection-gateway.vo.ts
@@ -12,7 +12,8 @@ export type ConnectionGatewayCapability = z.infer<typeof ConnectionGatewayCapabi
 export const ConnectionGatewaySessionScopeSchema = z.object({
   userId: z.string().min(1),
   teamId: z.string().min(1).optional(),
-  source: z.string().min(1).optional()
+  source: z.string().min(1).optional(),
+  sources: z.array(z.string().min(1)).optional()
 });
 export type ConnectionGatewaySessionScope = z.infer<typeof ConnectionGatewaySessionScopeSchema>;
 
@@ -62,7 +63,8 @@ export const ConnectionGatewaySessionSchema = z.object({
   status: ConnectionGatewaySessionStatusSchema,
   connectedAt: z.number().int().positive(),
   lastSeenAt: z.number().int().positive(),
-  expiresAt: z.number().int().positive()
+  expiresAt: z.number().int().positive(),
+  metadata: z.record(z.string(), z.unknown()).optional()
 });
 export type ConnectionGatewaySession = z.infer<typeof ConnectionGatewaySessionSchema>;
 

--- a/packages/infrastructure/src/connection-gateway/mailbox.test.ts
+++ b/packages/infrastructure/src/connection-gateway/mailbox.test.ts
@@ -1,10 +1,10 @@
 import '@infrastructure/errors/error.registry';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
 
-import { InMemoryConnectionGatewayMailbox } from './mailbox';
+import { InMemoryConnectionGatewayMailbox, RedisConnectionGatewayMailbox } from './mailbox';
 
 function makeEnvelope(id: string): ConnectionGatewayEnvelope {
   return {
@@ -41,3 +41,88 @@ describe('InMemoryConnectionGatewayMailbox', () => {
     await expect(mailbox.lag('session-a')).resolves.toBe(1);
   });
 });
+
+describe('RedisConnectionGatewayMailbox', () => {
+  it('uses a dedicated duplicate Redis connection for blocking reads', async () => {
+    const blockingRedis = makeRedisStub({
+      callResult: [
+        [
+          'fastgpt-plugin:connection-gateway:mailbox:session-a',
+          [['1-0', ['envelope', JSON.stringify(makeEnvelope('first'))]]]
+        ]
+      ]
+    });
+    const redis = makeRedisStub({
+      xaddResult: '1-0',
+      duplicateResult: blockingRedis
+    });
+    const mailbox = new RedisConnectionGatewayMailbox(redis as never, { maxLen: 100 });
+
+    await mailbox.publish('session-a', makeEnvelope('publish'));
+    await mailbox.read({ sessionId: 'session-a', blockMs: 5000, count: 1 });
+    await mailbox.ack('session-a', ['1-0']);
+    await mailbox.lag('session-a');
+    await mailbox.disconnect();
+
+    expect(redis.call).not.toHaveBeenCalled();
+    expect(blockingRedis.call).toHaveBeenCalledWith(
+      'XREAD',
+      'BLOCK',
+      5000,
+      'COUNT',
+      1,
+      'STREAMS',
+      'connection-gateway:mailbox:session-a',
+      '0-0'
+    );
+    expect(redis.xadd).toHaveBeenCalledTimes(1);
+    expect(redis.xdel).toHaveBeenCalledTimes(1);
+    expect(redis.xlen).toHaveBeenCalledTimes(1);
+    expect(blockingRedis.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses independent Redis connections for concurrent blocking reads', async () => {
+    const firstReader = makeRedisStub({
+      callResult: new Promise((resolve) => setTimeout(() => resolve(null), 10))
+    });
+    const secondReader = makeRedisStub({ callResult: null });
+    const redis = makeRedisStub({
+      duplicateResults: [firstReader, secondReader]
+    });
+    const mailbox = new RedisConnectionGatewayMailbox(redis as never, { maxLen: 100 });
+
+    const firstRead = mailbox.read({ sessionId: 'session-a', blockMs: 5000, count: 1 });
+    const secondRead = mailbox.read({ sessionId: 'reply:session-a:request-a', blockMs: 5000, count: 1 });
+
+    await expect(Promise.all([firstRead, secondRead])).resolves.toEqual([[], []]);
+
+    expect(redis.duplicate).toHaveBeenCalledTimes(2);
+    expect(firstReader.call).toHaveBeenCalledTimes(1);
+    expect(secondReader.call).toHaveBeenCalledTimes(1);
+    expect(firstReader.quit).toHaveBeenCalledTimes(1);
+    expect(secondReader.quit).toHaveBeenCalledTimes(1);
+  });
+});
+
+function makeRedisStub({
+  callResult = null,
+  duplicateResult,
+  duplicateResults,
+  xaddResult = '1-0'
+}: {
+  callResult?: unknown;
+  duplicateResult?: unknown;
+  duplicateResults?: unknown[];
+  xaddResult?: string;
+} = {}) {
+  return {
+    duplicate: vi.fn(() => duplicateResults?.shift() ?? duplicateResult),
+    xadd: vi.fn().mockResolvedValue(xaddResult),
+    call: vi.fn().mockResolvedValue(callResult),
+    xdel: vi.fn().mockResolvedValue(1),
+    xtrim: vi.fn().mockResolvedValue(1),
+    pexpire: vi.fn().mockResolvedValue(1),
+    xlen: vi.fn().mockResolvedValue(0),
+    quit: vi.fn().mockResolvedValue('OK')
+  };
+}

--- a/packages/infrastructure/src/connection-gateway/mailbox.ts
+++ b/packages/infrastructure/src/connection-gateway/mailbox.ts
@@ -76,6 +76,8 @@ export class InMemoryConnectionGatewayMailbox implements ConnectionGatewayMailbo
 }
 
 export class RedisConnectionGatewayMailbox implements ConnectionGatewayMailboxPort {
+  private readonly blockingReaders = new Set<Redis>();
+
   constructor(
     private readonly redis: Redis,
     private readonly options: {
@@ -160,12 +162,23 @@ export class RedisConnectionGatewayMailbox implements ConnectionGatewayMailboxPo
     return this.recordRedisRoundTrip(async () => this.redis.xlen(this.key(sessionId)));
   }
 
+  async disconnect(): Promise<void> {
+    await Promise.all([...this.blockingReaders].map((reader) => reader.quit()));
+  }
+
   private key(sessionId: string): string {
     return `${MAILBOX_KEY_PREFIX}:${sessionId}`;
   }
 
   private async xread(...args: Array<string | number>): Promise<RedisStreamResponse> {
-    return this.redis.call('XREAD', ...args) as Promise<RedisStreamResponse>;
+    const reader = this.redis.duplicate();
+    this.blockingReaders.add(reader);
+    try {
+      return (await reader.call('XREAD', ...args)) as RedisStreamResponse;
+    } finally {
+      this.blockingReaders.delete(reader);
+      await reader.quit();
+    }
   }
 
   private async recordRedisRoundTrip<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/infrastructure/src/connection-gateway/service.test.ts
+++ b/packages/infrastructure/src/connection-gateway/service.test.ts
@@ -36,6 +36,7 @@ function makeService(overrides: { maxSessionsPerSubject?: number } = {}) {
         nodeId: 'node-a',
         sessionTtlMs: 60_000,
         ownerLeaseTtlMs: 15_000,
+        mailboxBlockMs: 10,
         mailboxMaxLen: 100
       }
     }),
@@ -44,6 +45,21 @@ function makeService(overrides: { maxSessionsPerSubject?: number } = {}) {
 }
 
 async function signDebugToken(token: HmacConnectionGatewayToken) {
+  return token.sign({
+    consumerType: 'plugin-debug',
+    subject: 'user:u1',
+    sessionScope: {
+      userId: 'u1',
+      source: 'debug:user:u1'
+    },
+    transport: 'tcp',
+    capabilities: ['invoke'],
+    issuedAt: now,
+    expiresAt: now + 60_000
+  });
+}
+
+async function signMultiSourceDebugToken(token: HmacConnectionGatewayToken) {
   return token.sign({
     consumerType: 'plugin-debug',
     subject: 'user:u1',
@@ -140,6 +156,120 @@ describe('ConnectionGatewayService', () => {
       })
     ).rejects.toMatchObject({
       code: 'connection_gateway.resource_limit_exceeded'
+    });
+  });
+
+  it('streams reply envelopes for a published request', async () => {
+    const { service, token } = makeService();
+    const session = await service.createSession({
+      token: await signDebugToken(token),
+      transport: 'tcp',
+      now
+    });
+    const request = makeEnvelope(session.id, session.generation);
+    const { responses } = await service.publishRequestAndWait({
+      sessionId: session.id,
+      envelope: request,
+      timeoutMs: 1_000
+    });
+    const iterator = responses[Symbol.asyncIterator]();
+
+    await service.publishResponse({
+      sessionId: session.id,
+      envelope: {
+        ...request,
+        type: 'response',
+        payload: {
+          kind: 'plugin-debug.accepted'
+        }
+      }
+    });
+    await service.publishResponse({
+      sessionId: session.id,
+      envelope: {
+        ...request,
+        type: 'stream',
+        payload: {
+          kind: 'plugin-debug.stream',
+          event: 'chunk',
+          data: { type: 'stream', data: { type: 'answer', content: 'hello' } }
+        }
+      }
+    });
+    await service.publishResponse({
+      sessionId: session.id,
+      envelope: {
+        ...request,
+        type: 'stream',
+        payload: {
+          kind: 'plugin-debug.stream',
+          event: 'end'
+        }
+      }
+    });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: expect.objectContaining({
+        type: 'response',
+        payload: expect.objectContaining({ kind: 'plugin-debug.accepted' })
+      })
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: expect.objectContaining({
+        type: 'stream',
+        payload: expect.objectContaining({ event: 'chunk' })
+      })
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: expect.objectContaining({
+        type: 'stream',
+        payload: expect.objectContaining({ event: 'end' })
+      })
+    });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it('finds a debug session through its channel source', async () => {
+    const { service, token } = makeService();
+    const session = await service.createSession({
+      token: await signMultiSourceDebugToken(token),
+      transport: 'tcp',
+      now
+    });
+
+    await expect(service.getLatestStatusBySource('debug:user:u1')).resolves.toMatchObject({
+      session: expect.objectContaining({
+        id: session.id
+      })
+    });
+  });
+
+  it('denies response envelopes without the session capability', async () => {
+    const { service, token } = makeService();
+    const session = await service.createSession({
+      token: await signDebugToken(token),
+      transport: 'tcp',
+      now
+    });
+
+    await expect(
+      service.publishResponse({
+        sessionId: session.id,
+        envelope: {
+          ...makeEnvelope(session.id, session.generation),
+          type: 'response',
+          capability: 'admin',
+          payload: {
+            kind: 'plugin-debug.error',
+            message: 'forbidden'
+          }
+        }
+      })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.capability_denied'
     });
   });
 });

--- a/packages/infrastructure/src/connection-gateway/service.ts
+++ b/packages/infrastructure/src/connection-gateway/service.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
+import type { ConnectionGatewayTokenVerifierPort } from '@domain/ports/connection-gateway/connection-token.port';
 import type { ConnectionGatewayMailboxPort } from '@domain/ports/connection-gateway/mailbox.port';
 import type { ConnectionGatewayMetricsPort } from '@domain/ports/connection-gateway/metrics.port';
 import type { ConnectionGatewaySessionRegistryPort } from '@domain/ports/connection-gateway/session-registry.port';
-import type { ConnectionGatewayTokenVerifierPort } from '@domain/ports/connection-gateway/connection-token.port';
 import {
   type ConnectionGatewayEnvelope,
   ConnectionGatewayEnvelopeSchema,
@@ -23,6 +23,7 @@ export type ConnectionGatewayServiceOptions = {
   nodeId: string;
   sessionTtlMs: number;
   ownerLeaseTtlMs: number;
+  mailboxBlockMs: number;
   mailboxMaxLen: number;
 };
 
@@ -47,6 +48,7 @@ export class ConnectionGatewayService {
   async createSession(input: {
     token: string;
     transport: ConnectionGatewayTransport;
+    metadata?: Record<string, unknown>;
     now?: number;
   }): Promise<ConnectionGatewaySession> {
     const now = input.now ?? Date.now();
@@ -68,6 +70,7 @@ export class ConnectionGatewayService {
       capabilities: claims.capabilities,
       ownerNodeId: this.deps.options.nodeId,
       expiresAt,
+      metadata: input.metadata,
       now
     });
 
@@ -96,6 +99,22 @@ export class ConnectionGatewayService {
     };
   }
 
+  async getLatestStatusBySource(source: string): Promise<ConnectionGatewaySessionStatusView> {
+    const sessions = await this.deps.sessionRegistry.listBySource(source);
+    const session = sessions.sort((a, b) => b.lastSeenAt - a.lastSeenAt)[0] ?? null;
+
+    if (!session) {
+      return {
+        session: null,
+        ownerAlive: false,
+        mailboxLag: 0,
+        logs: []
+      };
+    }
+
+    return this.getStatus(session.id);
+  }
+
   async publishRequest(input: {
     sessionId: string;
     envelope: ConnectionGatewayEnvelope;
@@ -103,39 +122,7 @@ export class ConnectionGatewayService {
     const envelope = ConnectionGatewayEnvelopeSchema.parse(input.envelope);
     this.deps.limiter.assertEnvelopeBytes(envelope);
 
-    const session = await this.deps.sessionRegistry.get(input.sessionId);
-    if (!session) {
-      throw createError(ErrorCode.connectionGatewaySessionNotFound);
-    }
-
-    if (session.expiresAt <= Date.now()) {
-      this.deps.metrics.recordOwnerLeaseExpiry();
-      throw createError(ErrorCode.connectionGatewaySessionOwnerExpired);
-    }
-
-    if (envelope.generation !== session.generation) {
-      throw createError(ErrorCode.connectionGatewayStaleGeneration, {
-        data: {
-          expectedGeneration: session.generation,
-          actualGeneration: envelope.generation
-        }
-      });
-    }
-
-    if (envelope.consumerType !== session.consumerType) {
-      throw createError(ErrorCode.connectionGatewayInvalidToken, {
-        data: {
-          expectedConsumerType: session.consumerType,
-          actualConsumerType: envelope.consumerType
-        }
-      });
-    }
-
-    if (envelope.capability && !session.capabilities.includes(envelope.capability)) {
-      throw createError(ErrorCode.connectionGatewayCapabilityDenied, {
-        data: { capability: envelope.capability }
-      });
-    }
+    const session = await this.assertEnvelopeSession(input.sessionId, envelope);
 
     this.deps.limiter.acquireInFlight(session.id);
     this.deps.metrics.recordRequestStarted(session.id);
@@ -157,6 +144,107 @@ export class ConnectionGatewayService {
       this.deps.metrics.recordRequestCompleted(session.id);
       this.deps.limiter.releaseInFlight(session.id);
     }
+  }
+
+  async publishRequestAndWait(input: {
+    sessionId: string;
+    envelope: ConnectionGatewayEnvelope;
+    timeoutMs?: number;
+  }): Promise<{
+    requestId: string;
+    responses: AsyncIterable<ConnectionGatewayEnvelope>;
+  }> {
+    const requestId = input.envelope.requestId ?? randomUUID();
+    const envelope = ConnectionGatewayEnvelopeSchema.parse({
+      ...input.envelope,
+      requestId
+    });
+    const replyMailboxId = this.getReplyMailboxId(input.sessionId, requestId);
+
+    await this.deps.mailbox.expire(replyMailboxId, this.deps.options.sessionTtlMs);
+    await this.publishRequest({
+      sessionId: input.sessionId,
+      envelope
+    });
+
+    return {
+      requestId,
+      responses: this.readReplyEnvelopes({
+        sessionId: input.sessionId,
+        requestId,
+        timeoutMs: input.timeoutMs ?? this.deps.options.sessionTtlMs
+      })
+    };
+  }
+
+  async publishResponse(input: {
+    sessionId: string;
+    envelope: ConnectionGatewayEnvelope;
+  }): Promise<{ messageId: string; accepted: true }> {
+    const envelope = ConnectionGatewayEnvelopeSchema.parse(input.envelope);
+    this.deps.limiter.assertEnvelopeBytes(envelope);
+    await this.assertEnvelopeSession(input.sessionId, envelope);
+
+    if (!envelope.requestId) {
+      throw createError(ErrorCode.connectionGatewayInvalidToken, {
+        message: 'Gateway response envelope requires requestId'
+      });
+    }
+
+    const replyMailboxId = this.getReplyMailboxId(input.sessionId, envelope.requestId);
+    const messageId = await this.deps.mailbox.publish(replyMailboxId, envelope);
+    await this.deps.mailbox.expire(replyMailboxId, this.deps.options.sessionTtlMs);
+    this.pushLog(input.sessionId, 'debug', 'Gateway response envelope published', {
+      messageId,
+      type: envelope.type,
+      requestId: envelope.requestId
+    });
+
+    return { messageId, accepted: true };
+  }
+
+  async bindSession(input: {
+    sessionId: string;
+    envelope: ConnectionGatewayEnvelope;
+  }): Promise<ConnectionGatewaySession> {
+    const envelope = ConnectionGatewayEnvelopeSchema.parse(input.envelope);
+    const session = await this.assertEnvelopeSession(input.sessionId, envelope, {
+      requireCapability: false
+    });
+
+    if (envelope.type !== 'event' || envelope.capability !== 'gateway.bind') {
+      throw createError(ErrorCode.connectionGatewayInvalidToken, {
+        message: 'Gateway bind envelope is invalid'
+      });
+    }
+
+    await this.renewOwnerLease(session.id);
+    this.pushLog(session.id, 'info', 'Gateway TCP session bound', {
+      consumerType: session.consumerType,
+      subject: session.subject,
+      transport: session.transport,
+      generation: session.generation
+    });
+
+    return session;
+  }
+
+  async readSessionRequests(input: {
+    sessionId: string;
+    afterId?: string;
+    blockMs?: number;
+    count?: number;
+  }) {
+    return this.deps.mailbox.read({
+      sessionId: input.sessionId,
+      afterId: input.afterId,
+      blockMs: input.blockMs ?? this.deps.options.mailboxBlockMs,
+      count: input.count
+    });
+  }
+
+  async ackSessionRequests(sessionId: string, messageIds: string[]): Promise<void> {
+    await this.deps.mailbox.ack(sessionId, messageIds);
   }
 
   async deleteSession(sessionId: string): Promise<void> {
@@ -183,6 +271,107 @@ export class ConnectionGatewayService {
     return renewed;
   }
 
+  private async assertEnvelopeSession(
+    sessionId: string,
+    envelope: ConnectionGatewayEnvelope,
+    options: { requireCapability?: boolean } = {}
+  ): Promise<ConnectionGatewaySession> {
+    const session = await this.deps.sessionRegistry.get(sessionId);
+    if (!session) {
+      throw createError(ErrorCode.connectionGatewaySessionNotFound);
+    }
+
+    if (session.expiresAt <= Date.now()) {
+      this.deps.metrics.recordOwnerLeaseExpiry();
+      throw createError(ErrorCode.connectionGatewaySessionOwnerExpired);
+    }
+
+    if (envelope.sessionId !== session.id) {
+      throw createError(ErrorCode.connectionGatewaySessionNotFound);
+    }
+
+    if (envelope.generation !== session.generation) {
+      throw createError(ErrorCode.connectionGatewayStaleGeneration, {
+        data: {
+          expectedGeneration: session.generation,
+          actualGeneration: envelope.generation
+        }
+      });
+    }
+
+    if (envelope.consumerType !== session.consumerType) {
+      throw createError(ErrorCode.connectionGatewayInvalidToken, {
+        data: {
+          expectedConsumerType: session.consumerType,
+          actualConsumerType: envelope.consumerType
+        }
+      });
+    }
+
+    if (
+      options.requireCapability !== false &&
+      envelope.capability &&
+      !session.capabilities.includes(envelope.capability)
+    ) {
+      throw createError(ErrorCode.connectionGatewayCapabilityDenied, {
+        data: { capability: envelope.capability }
+      });
+    }
+
+    return session;
+  }
+
+  private async *readReplyEnvelopes(input: {
+    sessionId: string;
+    requestId: string;
+    timeoutMs: number;
+  }): AsyncIterable<ConnectionGatewayEnvelope> {
+    const replyMailboxId = this.getReplyMailboxId(input.sessionId, input.requestId);
+    const deadline = Date.now() + input.timeoutMs;
+    let afterId: string | undefined = '0-0';
+
+    while (Date.now() < deadline) {
+      const remainingMs = Math.max(1, deadline - Date.now());
+      const messages = await this.deps.mailbox.read({
+        sessionId: replyMailboxId,
+        afterId,
+        blockMs: Math.min(this.deps.options.mailboxBlockMs, remainingMs),
+        count: 10
+      });
+
+      if (messages.length === 0) {
+        continue;
+      }
+
+      afterId = messages[messages.length - 1].id;
+      await this.deps.mailbox.ack(
+        replyMailboxId,
+        messages.map((message) => message.id)
+      );
+
+      for (const message of messages) {
+        yield message.envelope;
+
+        if (isTerminalReplyEnvelope(message.envelope)) {
+          return;
+        }
+      }
+    }
+
+    throw createError(ErrorCode.connectionGatewaySessionOwnerExpired, {
+      message: 'Gateway request timed out waiting for response',
+      data: {
+        sessionId: input.sessionId,
+        requestId: input.requestId,
+        timeoutMs: input.timeoutMs
+      }
+    });
+  }
+
+  private getReplyMailboxId(sessionId: string, requestId: string): string {
+    return `reply:${sessionId}:${requestId}`;
+  }
+
   private pushLog(
     sessionId: string,
     level: GatewayLogEntry['level'],
@@ -198,4 +387,22 @@ export class ConnectionGatewayService {
     });
     this.logs.set(sessionId, logs.slice(-100));
   }
+}
+
+function isTerminalReplyEnvelope(envelope: ConnectionGatewayEnvelope): boolean {
+  if (envelope.type === 'response') {
+    if (!envelope.payload || typeof envelope.payload !== 'object') {
+      return true;
+    }
+
+    const payload = envelope.payload as { kind?: unknown };
+    return payload.kind !== 'plugin-debug.accepted';
+  }
+
+  if (envelope.type !== 'stream' || !envelope.payload || typeof envelope.payload !== 'object') {
+    return false;
+  }
+
+  const payload = envelope.payload as { event?: unknown };
+  return payload.event === 'end' || payload.event === 'error';
 }

--- a/packages/infrastructure/src/connection-gateway/session-registry.test.ts
+++ b/packages/infrastructure/src/connection-gateway/session-registry.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { RedisConnectionGatewaySessionRegistry } from './session-registry';
+
+describe('RedisConnectionGatewaySessionRegistry', () => {
+  it('renews subject and source index TTLs with the owner lease', async () => {
+    const now = Date.now();
+    const redis = makeRedisStub();
+    const registry = new RedisConnectionGatewaySessionRegistry(redis as never, 60_000);
+    const session = await registry.create({
+      id: 'session-a',
+      consumerType: 'plugin-debug',
+      subject: 'user:u1',
+      sessionScope: {
+        userId: 'u1',
+        source: 'debug:user:u1'
+      },
+      transport: 'tcp',
+      capabilities: ['invoke'],
+      ownerNodeId: 'node-a',
+      expiresAt: now + 15_000,
+      metadata: {},
+      now
+    });
+
+    redis.ops.length = 0;
+
+    await expect(
+      registry.renewOwnerLease({
+        sessionId: session.id,
+        ownerNodeId: 'node-a',
+        expiresAt: now + 30_000,
+        now: now + 5_000
+      })
+    ).resolves.toBe(true);
+
+    expect(redis.ops).toContainEqual([
+      'pexpire',
+      'connection-gateway:sessions:by-subject:user:u1',
+      60_000
+    ]);
+    expect(redis.ops).toContainEqual([
+      'pexpire',
+      'connection-gateway:sessions:by-source:debug:user:u1',
+      60_000
+    ]);
+    await expect(registry.listBySource('debug:user:u1')).resolves.toEqual([
+      expect.objectContaining({
+        id: session.id,
+        expiresAt: now + 30_000,
+        lastSeenAt: now + 5_000
+      })
+    ]);
+  });
+});
+
+function makeRedisStub() {
+  const values = new Map<string, string>();
+  const sets = new Map<string, Set<string>>();
+  const redis = {
+    ops: [] as unknown[][],
+    get: async (key: string) => values.get(key) ?? null,
+    smembers: async (key: string) => [...(sets.get(key) ?? new Set<string>())],
+    keys: async (pattern: string) => {
+      const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
+
+      return [...values.keys()].filter((key) => key.startsWith(prefix));
+    },
+    multi: () => {
+      const multi = {
+        set: (key: string, value: string, mode: string, ttl: number) => {
+          redis.ops.push(['set', key, value, mode, ttl]);
+          values.set(key, value);
+          return multi;
+        },
+        sadd: (key: string, value: string) => {
+          redis.ops.push(['sadd', key, value]);
+          const set = sets.get(key) ?? new Set<string>();
+          set.add(value);
+          sets.set(key, set);
+          return multi;
+        },
+        pexpire: (key: string, ttl: number) => {
+          redis.ops.push(['pexpire', key, ttl]);
+          return multi;
+        },
+        del: (key: string) => {
+          redis.ops.push(['del', key]);
+          values.delete(key);
+          return multi;
+        },
+        srem: (key: string, value: string) => {
+          redis.ops.push(['srem', key, value]);
+          sets.get(key)?.delete(value);
+          return multi;
+        },
+        exec: async () => []
+      };
+
+      return multi;
+    }
+  };
+
+  return redis;
+}

--- a/packages/infrastructure/src/connection-gateway/session-registry.ts
+++ b/packages/infrastructure/src/connection-gateway/session-registry.ts
@@ -43,6 +43,13 @@ export class InMemoryConnectionGatewaySessionRegistry
     return [...this.sessions.values()].filter((session) => session.subject === subject);
   }
 
+  async listBySource(source: string): Promise<ConnectionGatewaySession[]> {
+    this.dropExpired(Date.now());
+    return [...this.sessions.values()].filter((session) =>
+      getSessionSources(session).includes(source)
+    );
+  }
+
   async renewOwnerLease(input: RenewConnectionGatewayOwnerLeaseInput): Promise<boolean> {
     const session = await this.get(input.sessionId);
     if (!session || session.ownerNodeId !== input.ownerNodeId) {
@@ -111,12 +118,7 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
       lastSeenAt: now
     };
 
-    await this.redis
-      .multi()
-      .set(this.sessionKey(session.id), JSON.stringify(session), 'PX', this.ttlMs)
-      .sadd(this.subjectKey(session.subject), session.id)
-      .pexpire(this.subjectKey(session.subject), this.ttlMs)
-      .exec();
+    await this.saveSessionAndIndexes(session);
 
     return session;
   }
@@ -134,6 +136,7 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
         .del(this.sessionKey(sessionId))
         .srem(this.subjectKey(parsed.subject), sessionId)
         .exec();
+      await this.removeSourceIndexes(parsed, sessionId);
       return null;
     }
 
@@ -142,6 +145,13 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
 
   async listBySubject(subject: string): Promise<ConnectionGatewaySession[]> {
     const sessionIds = await this.redis.smembers(this.subjectKey(subject));
+    const sessions = await Promise.all(sessionIds.map((sessionId) => this.get(sessionId)));
+
+    return sessions.filter((session): session is ConnectionGatewaySession => session !== null);
+  }
+
+  async listBySource(source: string): Promise<ConnectionGatewaySession[]> {
+    const sessionIds = await this.redis.smembers(this.sourceKey(source));
     const sessions = await Promise.all(sessionIds.map((sessionId) => this.get(sessionId)));
 
     return sessions.filter((session): session is ConnectionGatewaySession => session !== null);
@@ -158,7 +168,7 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
       expiresAt: input.expiresAt,
       lastSeenAt: input.now ?? Date.now()
     };
-    await this.redis.set(this.sessionKey(session.id), JSON.stringify(next), 'PX', this.ttlMs);
+    await this.saveSessionAndIndexes(next);
     return true;
   }
 
@@ -178,7 +188,7 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
       status: input.status,
       lastSeenAt: input.now ?? Date.now()
     };
-    await this.redis.set(this.sessionKey(session.id), JSON.stringify(next), 'PX', this.ttlMs);
+    await this.saveSessionAndIndexes(next);
     return true;
   }
 
@@ -188,6 +198,9 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
 
     if (session) {
       multi.srem(this.subjectKey(session.subject), sessionId);
+      for (const source of getSessionSources(session)) {
+        multi.srem(this.sourceKey(source), sessionId);
+      }
     }
 
     await multi.exec();
@@ -205,4 +218,46 @@ export class RedisConnectionGatewaySessionRegistry implements ConnectionGatewayS
   private subjectKey(subject: string): string {
     return `${SESSION_KEY_PREFIX}:by-subject:${subject}`;
   }
+
+  private sourceKey(source: string): string {
+    return `${SESSION_KEY_PREFIX}:by-source:${source}`;
+  }
+
+  private async saveSessionAndIndexes(session: ConnectionGatewaySession): Promise<void> {
+    const multi = this.redis
+      .multi()
+      .set(this.sessionKey(session.id), JSON.stringify(session), 'PX', this.ttlMs)
+      .sadd(this.subjectKey(session.subject), session.id)
+      .pexpire(this.subjectKey(session.subject), this.ttlMs);
+
+    for (const source of getSessionSources(session)) {
+      multi.sadd(this.sourceKey(source), session.id);
+      multi.pexpire(this.sourceKey(source), this.ttlMs);
+    }
+
+    await multi.exec();
+  }
+
+  private async removeSourceIndexes(
+    session: ConnectionGatewaySession,
+    sessionId: string
+  ): Promise<void> {
+    const sources = getSessionSources(session);
+    if (sources.length === 0) {
+      return;
+    }
+
+    const multi = this.redis.multi();
+    for (const source of sources) {
+      multi.srem(this.sourceKey(source), sessionId);
+    }
+    await multi.exec();
+  }
+}
+
+function getSessionSources(session: ConnectionGatewaySession): string[] {
+  return [
+    ...(session.sessionScope.source ? [session.sessionScope.source] : []),
+    ...(session.sessionScope.sources ?? [])
+  ].filter((source, index, sources) => sources.indexOf(source) === index);
 }

--- a/packages/infrastructure/src/env/index.test.ts
+++ b/packages/infrastructure/src/env/index.test.ts
@@ -5,6 +5,7 @@ const originalEnv = process.env;
 const resetEnv = () => {
   process.env = { ...originalEnv };
   delete process.env.AUTH_TOKEN;
+  delete process.env.CONNECTION_GATEWAY_AUTH_TOKEN;
   delete process.env.NODE_ENV;
   delete process.env.DISABLE_SSRF_CHECK;
   delete process.env.METRICS_ENABLE_OTEL;
@@ -32,30 +33,75 @@ describe('env AUTH_TOKEN', () => {
   it('requires AUTH_TOKEN in production', async () => {
     process.env.NODE_ENV = 'production';
 
-    await expect(import('./index')).rejects.toThrow('AUTH_TOKEN');
+    const { env } = await import('./index');
+
+    expect(() => env.AUTH_TOKEN).toThrow('AUTH_TOKEN');
   });
 
   it('rejects default AUTH_TOKEN values in production', async () => {
     process.env.NODE_ENV = 'production';
     process.env.AUTH_TOKEN = 'token';
 
-    await expect(import('./index')).rejects.toThrow('AUTH_TOKEN');
+    const { env } = await import('./index');
+
+    expect(() => env.AUTH_TOKEN).toThrow('AUTH_TOKEN');
   });
 
   it('rejects short AUTH_TOKEN values in production', async () => {
     process.env.NODE_ENV = 'production';
     process.env.AUTH_TOKEN = 'short-token';
 
-    await expect(import('./index')).rejects.toThrow('AUTH_TOKEN');
+    const { env } = await import('./index');
+
+    expect(() => env.AUTH_TOKEN).toThrow('AUTH_TOKEN');
   });
 
   it('accepts a strong AUTH_TOKEN in production', async () => {
     process.env.NODE_ENV = 'production';
     process.env.AUTH_TOKEN = 'a'.repeat(32);
+    process.env.CONNECTION_GATEWAY_AUTH_TOKEN = 'b'.repeat(32);
 
     const { env } = await import('./index');
 
     expect(env.AUTH_TOKEN).toBe('a'.repeat(32));
+  });
+
+  it('allows server auth token and gateway auth token to differ', async () => {
+    process.env.AUTH_TOKEN = 'server-token';
+    process.env.CONNECTION_GATEWAY_AUTH_TOKEN = 'gateway-token';
+
+    const { serverEnv } = await import('./index');
+
+    expect(serverEnv.AUTH_TOKEN).toBe('server-token');
+    expect(serverEnv.CONNECTION_GATEWAY_AUTH_TOKEN).toBe('gateway-token');
+  });
+
+  it('falls back to AUTH_TOKEN for gateway auth token in local development', async () => {
+    process.env.AUTH_TOKEN = 'server-and-gateway-token';
+
+    const { serverEnv } = await import('./index');
+
+    expect(serverEnv.CONNECTION_GATEWAY_AUTH_TOKEN).toBe('server-and-gateway-token');
+  });
+
+  it('requires an explicit gateway auth token in production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_TOKEN = 'a'.repeat(32);
+
+    const { serverEnv } = await import('./index');
+
+    expect(() => serverEnv.CONNECTION_GATEWAY_AUTH_TOKEN).toThrow('CONNECTION_GATEWAY_AUTH_TOKEN');
+  });
+
+  it('accepts different strong server and gateway auth tokens in production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_TOKEN = 's'.repeat(32);
+    process.env.CONNECTION_GATEWAY_AUTH_TOKEN = 'g'.repeat(32);
+
+    const { serverEnv } = await import('./index');
+
+    expect(serverEnv.AUTH_TOKEN).toBe('s'.repeat(32));
+    expect(serverEnv.CONNECTION_GATEWAY_AUTH_TOKEN).toBe('g'.repeat(32));
   });
 
   it('keeps metrics disabled by default', async () => {
@@ -70,12 +116,41 @@ describe('env AUTH_TOKEN', () => {
   it('rejects invalid metrics OTLP URLs', async () => {
     process.env.METRICS_OTEL_URL = 'not-a-url';
 
-    await expect(import('./index')).rejects.toThrow('METRICS_OTEL_URL');
+    const { env } = await import('./index');
+
+    expect(() => env.METRICS_OTEL_URL).toThrow('METRICS_OTEL_URL');
   });
 
   it('rejects non-positive metrics export timings', async () => {
     process.env.METRICS_EXPORT_INTERVAL_MS = '0';
 
-    await expect(import('./index')).rejects.toThrow('METRICS_EXPORT_INTERVAL_MS');
+    const { env } = await import('./index');
+
+    expect(() => env.METRICS_EXPORT_INTERVAL_MS).toThrow('METRICS_EXPORT_INTERVAL_MS');
+  });
+
+  it('does not require server gateway client token when only gateway env is read', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_TOKEN = 'g'.repeat(32);
+
+    const { gatewayEnv } = await import('./index');
+
+    expect(gatewayEnv.AUTH_TOKEN).toBe('g'.repeat(32));
+  });
+
+  it('does not require server gateway client token when gateway imports auth middleware factory', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_TOKEN = 'g'.repeat(32);
+
+    await expect(import('../hono/middleware/auth')).resolves.toHaveProperty(
+      'createBearerHonoAuthMiddleware'
+    );
+  });
+
+  it('does not require server gateway client token when gateway imports shared Redis client', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.AUTH_TOKEN = 'g'.repeat(32);
+
+    await expect(import('../redis/redis-client')).resolves.toHaveProperty('RedisClient');
   });
 });

--- a/packages/infrastructure/src/env/index.ts
+++ b/packages/infrastructure/src/env/index.ts
@@ -1,7 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
 
-import { createEnv } from '@t3-oss/env-core';
 import { z } from 'zod';
 
 import { BoolStringSchema, PositiveIntSchema } from '@domain/value-objects/baisc.vo';
@@ -40,137 +39,335 @@ const AuthTokenSchema = z
     return token;
   });
 
-export const env = createEnv({
-  runtimeEnv: process.env,
-  emptyStringAsUndefined: true,
-  isServer: true,
-  onValidationError(issues) {
-    const paths = issues.map((issue) => issue.path).join(', ');
+const GatewayAuthTokenSchema = z
+  .string()
+  .trim()
+  .optional()
+  .transform((value, ctx) => {
+    if (process.env.NODE_ENV !== 'production') {
+      return value || process.env.AUTH_TOKEN || DEV_AUTH_TOKEN;
+    }
+
+    const token = value;
+    if (!token) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'CONNECTION_GATEWAY_AUTH_TOKEN is required in production'
+      });
+    } else if (
+      token.length < MIN_PRODUCTION_AUTH_TOKEN_LENGTH ||
+      WEAK_AUTH_TOKENS.has(token.toLowerCase())
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `CONNECTION_GATEWAY_AUTH_TOKEN must be at least ${MIN_PRODUCTION_AUTH_TOKEN_LENGTH} characters and not use a default value in production`
+      });
+    }
+
+    return token;
+  });
+
+const createValidatedEnv = <TOutput>(schema: z.ZodRawShape): TOutput => {
+  const result = z.object(schema).safeParse(normalizeRuntimeEnv(process.env));
+  if (!result.success) {
+    const paths = result.error.issues.map((issue) => issue.path).join(', ');
     throw new Error(`Invalid environment variables. Please check: ${paths}\n`);
-  },
-  server: {
-    // 基础配置
-    NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-
-    // 服务器配置
-    PORT: PositiveIntSchema.min(1024).max(65535).default(3000),
-    AUTH_TOKEN: AuthTokenSchema,
-    JWT_SECRET: z.string().default('fastgpt-plugin-secret'),
-
-    // Connection Gateway 配置
-    CONNECTION_GATEWAY_PORT: PositiveIntSchema.min(1024).max(65535).default(3010),
-    CONNECTION_GATEWAY_TCP_PORT: PositiveIntSchema.min(1024).max(65535).default(3011),
-    CONNECTION_GATEWAY_NODE_ID: z.string().optional(),
-    CONNECTION_GATEWAY_SESSION_TTL_MS: PositiveIntSchema.default(60_000),
-    CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS: PositiveIntSchema.default(15_000),
-    CONNECTION_GATEWAY_MAILBOX_MAXLEN: PositiveIntSchema.default(1_000),
-    CONNECTION_GATEWAY_MAILBOX_BLOCK_MS: PositiveIntSchema.default(5_000),
-    CONNECTION_GATEWAY_MAX_CONNECTIONS: PositiveIntSchema.default(5_000),
-    CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT: PositiveIntSchema.default(5),
-    CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION: PositiveIntSchema.default(50),
-    CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES: PositiveIntSchema.default(1024 * 1024),
-    CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES: PositiveIntSchema.default(8 * 1024 * 1024),
-
-    // 安全配置
-    ALLOWED_INSTALL_HOSTS: z.string().optional(),
-    DISABLE_SSRF_CHECK: BoolStringSchema.default(false),
-
-    // 插件运行配置
-    PLUGIN_RUNTIME_MODE: PluginRuntimeModeSchema.default(PluginRuntimeModeEnum['localPool']),
-
-    // 进程池配置（插件级配置可被 MongoDB 中的 pluginConfig 覆盖）
-    // 进程池全局设置
-    POOL_HEALTH_CHECK_INTERVAL: PositiveIntSchema.default(30_000), // 健康检查时间 (ms)
-    POOL_MAX_TOTAL_PODS: PositiveIntSchema.default(100), // 最大总进程数
-
-    POOL_SERVICE_MIN_PODS: z.coerce.number().int().min(0).default(0), // 某个 Service 的最小进程数
-    POOL_SERVICE_MAX_PODS: PositiveIntSchema.default(5), // 某个 Service 的最大进程数
-    POOL_SERVICE_IDLE_TIMEOUT: PositiveIntSchema.default(60_000), // 全局空闲超时时间 (ms)
-    POOL_SERVICE_POD_TIMEOUT: PositiveIntSchema.default(120_000), // 进程运行超时时间 (ms)
-    POOL_SERVICE_MAX_CONCURRENT_REQUESTS_PER_POD: PositiveIntSchema.default(10), // 单个进程最大并发请求数
-    POOL_SERVICE_MAX_REQUESTS_PER_POD: PositiveIntSchema.default(100), // 全局单个进程最大请求数，超出后自动轮换
-    POOL_SERVICE_MAX_QUEUE_SIZE: PositiveIntSchema.default(500), // 全局进程队列最大长度
-    POOL_SERVICE_QUEUE_TIMEOUT: PositiveIntSchema.default(60_000), // 全局进程队列超时时间 (ms)
-    POOL_SERVICE_STARTUP_RETRY_BASE_DELAY: PositiveIntSchema.default(1_000), // 启动超时退避基础时间 (ms)
-    POOL_SERVICE_STARTUP_RETRY_MAX_DELAY: PositiveIntSchema.default(10_000), // 启动超时退避最大时间 (ms)
-
-    // 基础设施配置
-    // 文件存储配置
-    LOCAL_FILE_BASE_PATH: z.string().default(path.join(os.tmpdir(), 'fastgpt-plugin')),
-    S3_FILE_BASE_PATH: z.string().default('system/plugin'),
-
-    // 系统
-    HOSTNAME: z.string().optional(),
-    MAX_API_SIZE: PositiveIntSchema.default(10),
-    FASTGPT_BASE_URL: z.url().default('http://localhost:3000'),
-    SERVICE_REQUEST_MAX_CONTENT_LENGTH: PositiveIntSchema.default(10),
-    DISABLE_CACHE: BoolStringSchema.default(false),
-    MODEL_PROVIDER_PRIORITY: z.string().default(''),
-    MODEL_CHANNEL_PRIORITY: z.string().default(''),
-    MAX_FILE_SIZE: PositiveIntSchema.default(20 * 1024 * 1024),
-
-    // 代理
-    HTTP_PROXY: z.string().optional(),
-    HTTPS_PROXY: z.string().optional(),
-    NO_PROXY: z.string().optional(),
-    ALL_PROXY: z.string().optional(),
-
-    // 数据库
-    MONGODB_URI: z
-      .string()
-      .nonempty()
-      .default(
-        'mongodb://username:password@localhost:27017/fastgpt?authSource=admin&directConnection=true'
-      ),
-    MONGO_MAX_LINK: PositiveIntSchema.default(20),
-    SYNC_INDEX: BoolStringSchema.default(true),
-    REDIS_URL: z.string().nonempty().default('redis://default:password@localhost:6379/0'),
-
-    // 日志
-    LOG_ENABLE_CONSOLE: BoolStringSchema.default(true),
-    LOG_CONSOLE_LEVEL: z
-      .enum(['trace', 'debug', 'info', 'warning', 'error', 'fatal'])
-      .default('info'),
-    LOG_ENABLE_OTEL: BoolStringSchema.default(false),
-    LOG_OTEL_LEVEL: z.enum(['trace', 'debug', 'info', 'warning', 'error', 'fatal']).default('info'),
-    LOG_OTEL_SERVICE_NAME: z.string().default('fastgpt-plugin'),
-    LOG_OTEL_URL: z.url().default('http://localhost:4318/v1/logs'),
-
-    // 指标
-    METRICS_ENABLE_OTEL: BoolStringSchema.default(false),
-    METRICS_OTEL_SERVICE_NAME: z.string().default('fastgpt-plugin'),
-    METRICS_OTEL_URL: z.url().default('http://localhost:4318/v1/metrics'),
-    METRICS_EXPORT_INTERVAL_MS: PositiveIntSchema.default(30_000),
-    METRICS_EXPORT_TIMEOUT_MS: PositiveIntSchema.default(10_000),
-    METRICS_INCLUDE_PLUGIN_VERSION: BoolStringSchema.default(true),
-    METRICS_INCLUDE_PLUGIN_ETAG: BoolStringSchema.default(false),
-    METRICS_INCLUDE_HOSTNAME: BoolStringSchema.default(true),
-    SERVICE_INSTANCE_ID: z.string().optional(),
-    DEPLOYMENT_ENVIRONMENT: z.string().optional(),
-
-    // 对象存储
-    STORAGE_VENDOR: z.enum(['minio', 'aws-s3', 'cos', 'oss']).default('minio'),
-    STORAGE_REGION: z.string().default('us-east-1'),
-    STORAGE_ACCESS_KEY_ID: z.string().default('minioadmin'),
-    STORAGE_SECRET_ACCESS_KEY: z.string().default('minioadmin'),
-    STORAGE_PUBLIC_BUCKET: z.string().default('fastgpt-public'),
-    STORAGE_PRIVATE_BUCKET: z.string().default('fastgpt-private'),
-    STORAGE_EXTERNAL_ENDPOINT: z.url().default('http://localhost:9000'),
-    STORAGE_S3_ENDPOINT: z.url().default('http://localhost:9000'),
-    STORAGE_S3_FORCE_PATH_STYLE: BoolStringSchema.default(true),
-    STORAGE_S3_MAX_RETRIES: PositiveIntSchema.default(3),
-    STORAGE_PUBLIC_ACCESS_EXTRA_SUB_PATH: z.string().optional(),
-
-    // 可选的对象存储配置
-    // COS | OSS
-    STORAGE_COS_PROTOCOL: z.enum(['https:', 'http:']).default('https:'),
-    STORAGE_COS_USE_ACCELERATE: BoolStringSchema.default(false),
-    STORAGE_COS_CNAME_DOMAIN: z.string().optional(),
-    STORAGE_COS_PROXY: z.string().optional(),
-    STORAGE_OSS_ENDPOINT: z.url().optional(),
-    STORAGE_OSS_INTERNAL: BoolStringSchema.default(false),
-    STORAGE_OSS_SECURE: BoolStringSchema.default(true),
-    STORAGE_OSS_ENABLE_PROXY: BoolStringSchema.default(false),
-    STORAGE_OSS_CNAME: BoolStringSchema.default(false)
   }
-});
+
+  return result.data as TOutput;
+};
+
+const createLazyValidatedEnv = <TOutput extends object>(schema: z.ZodRawShape): TOutput => {
+  let cachedEnv: TOutput | undefined;
+  const getEnv = () => (cachedEnv ??= createValidatedEnv<TOutput>(schema));
+
+  return new Proxy(
+    {},
+    {
+      get(_target, property) {
+        return Reflect.get(getEnv(), property);
+      },
+      has(_target, property) {
+        return property in getEnv();
+      },
+      ownKeys() {
+        return Reflect.ownKeys(getEnv());
+      },
+      getOwnPropertyDescriptor(_target, property) {
+        return Reflect.getOwnPropertyDescriptor(getEnv(), property);
+      }
+    }
+  ) as TOutput;
+};
+
+function normalizeRuntimeEnv(runtimeEnv: NodeJS.ProcessEnv): Record<string, string | undefined> {
+  return Object.fromEntries(
+    Object.entries(runtimeEnv).map(([key, value]) => [key, value === '' ? undefined : value])
+  );
+}
+
+const NodeEnvSchema = z.enum(['development', 'production', 'test']).default('development');
+
+const CommonEnvSchema = {
+  NODE_ENV: NodeEnvSchema,
+
+  // 代理
+  HTTP_PROXY: z.string().optional(),
+  HTTPS_PROXY: z.string().optional(),
+  NO_PROXY: z.string().optional(),
+  ALL_PROXY: z.string().optional(),
+
+  // 数据库
+  MONGODB_URI: z
+    .string()
+    .nonempty()
+    .default(
+      'mongodb://username:password@localhost:27017/fastgpt?authSource=admin&directConnection=true'
+    ),
+  MONGO_MAX_LINK: PositiveIntSchema.default(20),
+  SYNC_INDEX: BoolStringSchema.default(true),
+  REDIS_URL: z.string().nonempty().default('redis://default:password@localhost:6379/0'),
+
+  // 日志
+  LOG_ENABLE_CONSOLE: BoolStringSchema.default(true),
+  LOG_CONSOLE_LEVEL: z.enum(['trace', 'debug', 'info', 'warning', 'error', 'fatal']).default('info'),
+  LOG_ENABLE_OTEL: BoolStringSchema.default(false),
+  LOG_OTEL_LEVEL: z.enum(['trace', 'debug', 'info', 'warning', 'error', 'fatal']).default('info'),
+  LOG_OTEL_SERVICE_NAME: z.string().default('fastgpt-plugin'),
+  LOG_OTEL_URL: z.url().default('http://localhost:4318/v1/logs'),
+
+  // 指标
+  METRICS_ENABLE_OTEL: BoolStringSchema.default(false),
+  METRICS_OTEL_SERVICE_NAME: z.string().default('fastgpt-plugin'),
+  METRICS_OTEL_URL: z.url().default('http://localhost:4318/v1/metrics'),
+  METRICS_EXPORT_INTERVAL_MS: PositiveIntSchema.default(30_000),
+  METRICS_EXPORT_TIMEOUT_MS: PositiveIntSchema.default(10_000),
+  METRICS_INCLUDE_PLUGIN_VERSION: BoolStringSchema.default(true),
+  METRICS_INCLUDE_PLUGIN_ETAG: BoolStringSchema.default(false),
+  METRICS_INCLUDE_HOSTNAME: BoolStringSchema.default(true),
+  SERVICE_INSTANCE_ID: z.string().optional(),
+  DEPLOYMENT_ENVIRONMENT: z.string().optional()
+};
+
+const ServerEnvSchema = {
+  ...CommonEnvSchema,
+
+  // 服务器配置
+  PORT: PositiveIntSchema.min(1024).max(65535).default(3000),
+  AUTH_TOKEN: AuthTokenSchema,
+  JWT_SECRET: z.string().default('fastgpt-plugin-secret'),
+
+  // Connection Gateway client 配置
+  CONNECTION_GATEWAY_BASE_URL: z.url().default('http://localhost:3010'),
+  CONNECTION_GATEWAY_AUTH_TOKEN: GatewayAuthTokenSchema,
+  CONNECTION_GATEWAY_DEBUG_REQUEST_TIMEOUT_MS: PositiveIntSchema.default(120_000),
+
+  // 安全配置
+  ALLOWED_INSTALL_HOSTS: z.string().optional(),
+  DISABLE_SSRF_CHECK: BoolStringSchema.default(false),
+
+  // 插件运行配置
+  PLUGIN_RUNTIME_MODE: PluginRuntimeModeSchema.default(PluginRuntimeModeEnum['localPool']),
+
+  // 进程池配置（插件级配置可被 MongoDB 中的 pluginConfig 覆盖）
+  POOL_HEALTH_CHECK_INTERVAL: PositiveIntSchema.default(30_000),
+  POOL_MAX_TOTAL_PODS: PositiveIntSchema.default(100),
+  POOL_SERVICE_MIN_PODS: z.coerce.number().int().min(0).default(0),
+  POOL_SERVICE_MAX_PODS: PositiveIntSchema.default(5),
+  POOL_SERVICE_IDLE_TIMEOUT: PositiveIntSchema.default(60_000),
+  POOL_SERVICE_POD_TIMEOUT: PositiveIntSchema.default(120_000),
+  POOL_SERVICE_MAX_CONCURRENT_REQUESTS_PER_POD: PositiveIntSchema.default(10),
+  POOL_SERVICE_MAX_REQUESTS_PER_POD: PositiveIntSchema.default(100),
+  POOL_SERVICE_MAX_QUEUE_SIZE: PositiveIntSchema.default(500),
+  POOL_SERVICE_QUEUE_TIMEOUT: PositiveIntSchema.default(60_000),
+  POOL_SERVICE_STARTUP_RETRY_BASE_DELAY: PositiveIntSchema.default(1_000),
+  POOL_SERVICE_STARTUP_RETRY_MAX_DELAY: PositiveIntSchema.default(10_000),
+
+  // 文件存储配置
+  LOCAL_FILE_BASE_PATH: z.string().default(path.join(os.tmpdir(), 'fastgpt-plugin')),
+  S3_FILE_BASE_PATH: z.string().default('system/plugin'),
+
+  // 系统
+  HOSTNAME: z.string().optional(),
+  MAX_API_SIZE: PositiveIntSchema.default(10),
+  FASTGPT_BASE_URL: z.url().default('http://localhost:3000'),
+  SERVICE_REQUEST_MAX_CONTENT_LENGTH: PositiveIntSchema.default(10),
+  DISABLE_CACHE: BoolStringSchema.default(false),
+  MODEL_PROVIDER_PRIORITY: z.string().default(''),
+  MODEL_CHANNEL_PRIORITY: z.string().default(''),
+  MAX_FILE_SIZE: PositiveIntSchema.default(20 * 1024 * 1024),
+
+  // 对象存储
+  STORAGE_VENDOR: z.enum(['minio', 'aws-s3', 'cos', 'oss']).default('minio'),
+  STORAGE_REGION: z.string().default('us-east-1'),
+  STORAGE_ACCESS_KEY_ID: z.string().default('minioadmin'),
+  STORAGE_SECRET_ACCESS_KEY: z.string().default('minioadmin'),
+  STORAGE_PUBLIC_BUCKET: z.string().default('fastgpt-public'),
+  STORAGE_PRIVATE_BUCKET: z.string().default('fastgpt-private'),
+  STORAGE_EXTERNAL_ENDPOINT: z.url().default('http://localhost:9000'),
+  STORAGE_S3_ENDPOINT: z.url().default('http://localhost:9000'),
+  STORAGE_S3_FORCE_PATH_STYLE: BoolStringSchema.default(true),
+  STORAGE_S3_MAX_RETRIES: PositiveIntSchema.default(3),
+  STORAGE_PUBLIC_ACCESS_EXTRA_SUB_PATH: z.string().optional(),
+
+  // 可选的对象存储配置
+  STORAGE_COS_PROTOCOL: z.enum(['https:', 'http:']).default('https:'),
+  STORAGE_COS_USE_ACCELERATE: BoolStringSchema.default(false),
+  STORAGE_COS_CNAME_DOMAIN: z.string().optional(),
+  STORAGE_COS_PROXY: z.string().optional(),
+  STORAGE_OSS_ENDPOINT: z.url().optional(),
+  STORAGE_OSS_INTERNAL: BoolStringSchema.default(false),
+  STORAGE_OSS_SECURE: BoolStringSchema.default(true),
+  STORAGE_OSS_ENABLE_PROXY: BoolStringSchema.default(false),
+  STORAGE_OSS_CNAME: BoolStringSchema.default(false)
+};
+
+const GatewayEnvSchema = {
+  ...CommonEnvSchema,
+
+  // Connection Gateway 服务配置
+  CONNECTION_GATEWAY_PORT: PositiveIntSchema.min(1024).max(65535).default(3010),
+  CONNECTION_GATEWAY_TCP_PORT: PositiveIntSchema.min(1024).max(65535).default(3011),
+  CONNECTION_GATEWAY_NODE_ID: z.string().optional(),
+  CONNECTION_GATEWAY_SESSION_TTL_MS: PositiveIntSchema.default(60_000),
+  CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS: PositiveIntSchema.default(15_000),
+  CONNECTION_GATEWAY_MAILBOX_MAXLEN: PositiveIntSchema.default(1_000),
+  CONNECTION_GATEWAY_MAILBOX_BLOCK_MS: PositiveIntSchema.default(5_000),
+  CONNECTION_GATEWAY_MAX_CONNECTIONS: PositiveIntSchema.default(5_000),
+  CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT: PositiveIntSchema.default(5),
+  CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION: PositiveIntSchema.default(50),
+  CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES: PositiveIntSchema.default(1024 * 1024),
+  CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES: PositiveIntSchema.default(8 * 1024 * 1024),
+
+  // 认证配置
+  AUTH_TOKEN: AuthTokenSchema,
+  JWT_SECRET: z.string().default('fastgpt-plugin-secret')
+};
+
+export type ServerEnv = {
+  NODE_ENV: 'development' | 'production' | 'test';
+  PORT: number;
+  AUTH_TOKEN: string;
+  JWT_SECRET: string;
+  CONNECTION_GATEWAY_BASE_URL: string;
+  CONNECTION_GATEWAY_AUTH_TOKEN: string;
+  CONNECTION_GATEWAY_DEBUG_REQUEST_TIMEOUT_MS: number;
+  HTTP_PROXY?: string;
+  HTTPS_PROXY?: string;
+  NO_PROXY?: string;
+  ALL_PROXY?: string;
+  MONGODB_URI: string;
+  MONGO_MAX_LINK: number;
+  SYNC_INDEX: boolean;
+  REDIS_URL: string;
+  LOG_ENABLE_CONSOLE: boolean;
+  LOG_CONSOLE_LEVEL: 'trace' | 'debug' | 'info' | 'warning' | 'error' | 'fatal';
+  LOG_ENABLE_OTEL: boolean;
+  LOG_OTEL_LEVEL: 'trace' | 'debug' | 'info' | 'warning' | 'error' | 'fatal';
+  LOG_OTEL_SERVICE_NAME: string;
+  LOG_OTEL_URL: string;
+  METRICS_ENABLE_OTEL: boolean;
+  METRICS_OTEL_SERVICE_NAME: string;
+  METRICS_OTEL_URL: string;
+  METRICS_EXPORT_INTERVAL_MS: number;
+  METRICS_EXPORT_TIMEOUT_MS: number;
+  METRICS_INCLUDE_PLUGIN_VERSION: boolean;
+  METRICS_INCLUDE_PLUGIN_ETAG: boolean;
+  METRICS_INCLUDE_HOSTNAME: boolean;
+  SERVICE_INSTANCE_ID?: string;
+  DEPLOYMENT_ENVIRONMENT?: string;
+  ALLOWED_INSTALL_HOSTS?: string;
+  DISABLE_SSRF_CHECK: boolean;
+  PLUGIN_RUNTIME_MODE: 'localPool' | 'serverless';
+  POOL_HEALTH_CHECK_INTERVAL: number;
+  POOL_MAX_TOTAL_PODS: number;
+  POOL_SERVICE_MIN_PODS: number;
+  POOL_SERVICE_MAX_PODS: number;
+  POOL_SERVICE_IDLE_TIMEOUT: number;
+  POOL_SERVICE_POD_TIMEOUT: number;
+  POOL_SERVICE_MAX_CONCURRENT_REQUESTS_PER_POD: number;
+  POOL_SERVICE_MAX_REQUESTS_PER_POD: number;
+  POOL_SERVICE_MAX_QUEUE_SIZE: number;
+  POOL_SERVICE_QUEUE_TIMEOUT: number;
+  POOL_SERVICE_STARTUP_RETRY_BASE_DELAY: number;
+  POOL_SERVICE_STARTUP_RETRY_MAX_DELAY: number;
+  LOCAL_FILE_BASE_PATH: string;
+  S3_FILE_BASE_PATH: string;
+  HOSTNAME?: string;
+  MAX_API_SIZE: number;
+  FASTGPT_BASE_URL: string;
+  SERVICE_REQUEST_MAX_CONTENT_LENGTH: number;
+  DISABLE_CACHE: boolean;
+  MODEL_PROVIDER_PRIORITY: string;
+  MODEL_CHANNEL_PRIORITY: string;
+  MAX_FILE_SIZE: number;
+  STORAGE_VENDOR: 'minio' | 'aws-s3' | 'cos' | 'oss';
+  STORAGE_REGION: string;
+  STORAGE_ACCESS_KEY_ID: string;
+  STORAGE_SECRET_ACCESS_KEY: string;
+  STORAGE_PUBLIC_BUCKET: string;
+  STORAGE_PRIVATE_BUCKET: string;
+  STORAGE_EXTERNAL_ENDPOINT: string;
+  STORAGE_S3_ENDPOINT: string;
+  STORAGE_S3_FORCE_PATH_STYLE: boolean;
+  STORAGE_S3_MAX_RETRIES: number;
+  STORAGE_PUBLIC_ACCESS_EXTRA_SUB_PATH?: string;
+  STORAGE_COS_PROTOCOL: 'https:' | 'http:';
+  STORAGE_COS_USE_ACCELERATE: boolean;
+  STORAGE_COS_CNAME_DOMAIN?: string;
+  STORAGE_COS_PROXY?: string;
+  STORAGE_OSS_ENDPOINT?: string;
+  STORAGE_OSS_INTERNAL: boolean;
+  STORAGE_OSS_SECURE: boolean;
+  STORAGE_OSS_ENABLE_PROXY: boolean;
+  STORAGE_OSS_CNAME: boolean;
+};
+
+export type GatewayEnv = Pick<
+  ServerEnv,
+  | 'NODE_ENV'
+  | 'HTTP_PROXY'
+  | 'HTTPS_PROXY'
+  | 'NO_PROXY'
+  | 'ALL_PROXY'
+  | 'MONGODB_URI'
+  | 'MONGO_MAX_LINK'
+  | 'SYNC_INDEX'
+  | 'REDIS_URL'
+  | 'LOG_ENABLE_CONSOLE'
+  | 'LOG_CONSOLE_LEVEL'
+  | 'LOG_ENABLE_OTEL'
+  | 'LOG_OTEL_LEVEL'
+  | 'LOG_OTEL_SERVICE_NAME'
+  | 'LOG_OTEL_URL'
+  | 'METRICS_ENABLE_OTEL'
+  | 'METRICS_OTEL_SERVICE_NAME'
+  | 'METRICS_OTEL_URL'
+  | 'METRICS_EXPORT_INTERVAL_MS'
+  | 'METRICS_EXPORT_TIMEOUT_MS'
+  | 'METRICS_INCLUDE_PLUGIN_VERSION'
+  | 'METRICS_INCLUDE_PLUGIN_ETAG'
+  | 'METRICS_INCLUDE_HOSTNAME'
+  | 'SERVICE_INSTANCE_ID'
+  | 'DEPLOYMENT_ENVIRONMENT'
+  | 'AUTH_TOKEN'
+  | 'JWT_SECRET'
+> & {
+  CONNECTION_GATEWAY_PORT: number;
+  CONNECTION_GATEWAY_TCP_PORT: number;
+  CONNECTION_GATEWAY_NODE_ID?: string;
+  CONNECTION_GATEWAY_SESSION_TTL_MS: number;
+  CONNECTION_GATEWAY_OWNER_LEASE_TTL_MS: number;
+  CONNECTION_GATEWAY_MAILBOX_MAXLEN: number;
+  CONNECTION_GATEWAY_MAILBOX_BLOCK_MS: number;
+  CONNECTION_GATEWAY_MAX_CONNECTIONS: number;
+  CONNECTION_GATEWAY_MAX_SESSIONS_PER_SUBJECT: number;
+  CONNECTION_GATEWAY_MAX_IN_FLIGHT_PER_SESSION: number;
+  CONNECTION_GATEWAY_MAX_ENVELOPE_BYTES: number;
+  CONNECTION_GATEWAY_SLOW_CONSUMER_BUFFER_BYTES: number;
+};
+
+export const serverEnv: ServerEnv = createLazyValidatedEnv<ServerEnv>(ServerEnvSchema);
+export const gatewayEnv: GatewayEnv = createLazyValidatedEnv<GatewayEnv>(GatewayEnvSchema);
+
+export const env: ServerEnv = serverEnv;

--- a/packages/infrastructure/src/hono/middleware/auth.ts
+++ b/packages/infrastructure/src/hono/middleware/auth.ts
@@ -1,18 +1,31 @@
 import { createMiddleware } from 'hono/factory';
 import { HTTPException } from 'hono/http-exception';
 
-import { env } from '../../env';
+import { serverEnv } from '../../env';
 
 const PREFIX = 'Bearer ';
 
-export const bearerHonoAuthMiddleware = createMiddleware<Env>(async (c, next) => {
-  const authHeader = c.req.header('Authorization');
+function getBearerToken(authHeader: string | undefined) {
   if (!authHeader?.startsWith(PREFIX)) {
     throw new HTTPException(401, { message: 'Unauthorized' });
   }
 
-  const token = authHeader.slice(PREFIX.length);
-  if (token !== env.AUTH_TOKEN) {
+  return authHeader.slice(PREFIX.length);
+}
+
+export const createBearerHonoAuthMiddleware = (authToken: string) =>
+  createMiddleware<Env>(async (c, next) => {
+    const token = getBearerToken(c.req.header('Authorization'));
+    if (token !== authToken) {
+      throw new HTTPException(401, { message: 'Unauthorized' });
+    }
+
+    await next();
+  });
+
+export const bearerHonoAuthMiddleware = createMiddleware<Env>(async (c, next) => {
+  const token = getBearerToken(c.req.header('Authorization'));
+  if (token !== serverEnv.AUTH_TOKEN) {
     throw new HTTPException(401, { message: 'Unauthorized' });
   }
 

--- a/packages/infrastructure/src/logger/index.ts
+++ b/packages/infrastructure/src/logger/index.ts
@@ -14,22 +14,30 @@ import { env } from '../env';
 import type { LogCategory } from './categories';
 
 type LogLevel = 'trace' | 'debug' | 'info' | 'warning' | 'error' | 'fatal';
+type LoggerEnv = {
+  LOG_ENABLE_CONSOLE: boolean;
+  LOG_CONSOLE_LEVEL: LogLevel;
+  LOG_ENABLE_OTEL: boolean;
+  LOG_OTEL_SERVICE_NAME: string;
+  LOG_OTEL_URL: string;
+  LOG_OTEL_LEVEL: LogLevel;
+};
 export type Logger = ReturnType<typeof getOtelLogger>;
 
 const contextLocalStorage = new AsyncLocalStorage<Record<string, unknown>>();
 
 let configured = false;
-export async function configureLogger() {
+export async function configureLogger(runtimeEnv: LoggerEnv = env) {
   if (configured) {
     return;
   }
 
-  const enableConsole = env.LOG_ENABLE_CONSOLE;
-  const consoleLevel = env.LOG_CONSOLE_LEVEL;
-  const enableOtel = env.LOG_ENABLE_OTEL;
-  const otelServiceName = env.LOG_OTEL_SERVICE_NAME;
-  const otelUrl = env.LOG_OTEL_URL;
-  const otelLevel = env.LOG_OTEL_LEVEL;
+  const enableConsole = runtimeEnv.LOG_ENABLE_CONSOLE;
+  const consoleLevel = runtimeEnv.LOG_CONSOLE_LEVEL;
+  const enableOtel = runtimeEnv.LOG_ENABLE_OTEL;
+  const otelServiceName = runtimeEnv.LOG_OTEL_SERVICE_NAME;
+  const otelUrl = runtimeEnv.LOG_OTEL_URL;
+  const otelLevel = runtimeEnv.LOG_OTEL_LEVEL;
 
   let otelSinkEnabled = false;
 

--- a/packages/infrastructure/src/metrics/index.ts
+++ b/packages/infrastructure/src/metrics/index.ts
@@ -26,15 +26,33 @@ const INSTANCE_ID_PREFIX = 'fastgpt-plugin-';
 const generatedServiceInstanceId = `${INSTANCE_ID_PREFIX}${randomUUID()}`;
 const gaugeSources: RuntimeGaugeSource[] = [];
 
+type MetricsEnv = {
+  NODE_ENV: 'development' | 'production' | 'test';
+  METRICS_ENABLE_OTEL: boolean;
+  METRICS_OTEL_SERVICE_NAME: string;
+  METRICS_OTEL_URL: string;
+  METRICS_EXPORT_INTERVAL_MS: number;
+  METRICS_EXPORT_TIMEOUT_MS: number;
+  METRICS_INCLUDE_PLUGIN_VERSION: boolean;
+  METRICS_INCLUDE_PLUGIN_ETAG: boolean;
+  METRICS_INCLUDE_HOSTNAME: boolean;
+  SERVICE_INSTANCE_ID?: string;
+  DEPLOYMENT_ENVIRONMENT?: string;
+  HOSTNAME?: string;
+};
+
 let configured = false;
+let configuredEnv: MetricsEnv = env;
 let runtimeMetricsRecorder: RuntimeMetricsRecorder = createNoopRuntimeMetricsRecorder();
 
-export async function configureMetrics(): Promise<void> {
+export async function configureMetrics(runtimeEnv: MetricsEnv = env): Promise<void> {
   if (configured) {
     return;
   }
 
-  if (!env.METRICS_ENABLE_OTEL) {
+  configuredEnv = runtimeEnv;
+
+  if (!runtimeEnv.METRICS_ENABLE_OTEL) {
     runtimeMetricsRecorder = createNoopRuntimeMetricsRecorder();
     configured = true;
     return;
@@ -43,26 +61,27 @@ export async function configureMetrics(): Promise<void> {
   const logger = getLogger(infra.otel);
 
   await configureOtelMetrics({
-    defaultMeterName: env.METRICS_OTEL_SERVICE_NAME,
+    defaultMeterName: runtimeEnv.METRICS_OTEL_SERVICE_NAME,
     metrics: {
       enabled: true,
-      serviceName: env.METRICS_OTEL_SERVICE_NAME,
-      url: env.METRICS_OTEL_URL,
-      exportIntervalMillis: env.METRICS_EXPORT_INTERVAL_MS,
+      serviceName: runtimeEnv.METRICS_OTEL_SERVICE_NAME,
+      url: runtimeEnv.METRICS_OTEL_URL,
+      exportIntervalMillis: runtimeEnv.METRICS_EXPORT_INTERVAL_MS,
       additionalResource: createResource({
         'service.instance.id': getServiceInstanceId(),
-        'deployment.environment': getOptionalEnvText(env.DEPLOYMENT_ENVIRONMENT) ?? env.NODE_ENV,
-        ...(env.METRICS_INCLUDE_HOSTNAME
-          ? { 'host.name': getOptionalEnvText(env.HOSTNAME) ?? os.hostname() }
+        'deployment.environment':
+          getOptionalEnvText(runtimeEnv.DEPLOYMENT_ENVIRONMENT) ?? runtimeEnv.NODE_ENV,
+        ...(runtimeEnv.METRICS_INCLUDE_HOSTNAME
+          ? { 'host.name': getOptionalEnvText(runtimeEnv.HOSTNAME) ?? os.hostname() }
           : {})
       })
     }
   });
 
   runtimeMetricsRecorder = createRuntimeMetricsRecorder({
-    meter: getMeter(env.METRICS_OTEL_SERVICE_NAME),
-    includePluginVersion: env.METRICS_INCLUDE_PLUGIN_VERSION,
-    includePluginEtag: env.METRICS_INCLUDE_PLUGIN_ETAG,
+    meter: getMeter(runtimeEnv.METRICS_OTEL_SERVICE_NAME),
+    includePluginVersion: runtimeEnv.METRICS_INCLUDE_PLUGIN_VERSION,
+    includePluginEtag: runtimeEnv.METRICS_INCLUDE_PLUGIN_ETAG,
     gaugeSources: () => [...gaugeSources],
     onError: (message, error) => {
       logger.warn(message, { error });
@@ -77,7 +96,7 @@ export async function destroyMetrics(): Promise<void> {
   }
 
   try {
-    await withTimeout(disposeMetrics(), env.METRICS_EXPORT_TIMEOUT_MS);
+    await withTimeout(disposeMetrics(), configuredEnv.METRICS_EXPORT_TIMEOUT_MS);
   } finally {
     configured = false;
     runtimeMetricsRecorder = createNoopRuntimeMetricsRecorder();
@@ -101,7 +120,7 @@ export function registerRuntimeGaugeSource(source: RuntimeGaugeSource): () => vo
 }
 
 export function getServiceInstanceId(): string {
-  return getOptionalEnvText(env.SERVICE_INSTANCE_ID) ?? generatedServiceInstanceId;
+  return getOptionalEnvText(configuredEnv.SERVICE_INSTANCE_ID) ?? generatedServiceInstanceId;
 }
 
 export function __getRuntimeGaugeSourcesForTest(): RuntimeGaugeSource[] {

--- a/packages/infrastructure/src/plugin/debug-plugin.repo.test.ts
+++ b/packages/infrastructure/src/plugin/debug-plugin.repo.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { PluginRepoPort } from '@domain/ports/plugin/plugin-repo.port';
+import { successResult } from '@domain/value-objects/result.vo';
+
+import { DebugPluginRepoOverlay } from './debug-plugin.repo';
+
+describe('DebugPluginRepoOverlay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('selects plugin metadata by pluginId under one debug source', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(makeGatewayStatus()));
+    const repo = createRepo();
+
+    const [plugin, err] = await repo.getPluginByUserPluginId({
+      pluginId: 'dbops',
+      source: 'debug:user:u1'
+    });
+
+    expect(err).toBeNull();
+    expect(plugin).toMatchObject({
+      pluginId: 'dbops',
+      version: '0.2.0'
+    });
+  });
+
+  it('lists all debug plugins mounted under one source', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(makeGatewayStatus()));
+    const repo = createRepo();
+
+    const [plugins, err] = await repo.list({
+      sources: ['debug:user:u1']
+    });
+
+    expect(err).toBeNull();
+    expect(plugins?.map((plugin) => plugin.pluginId)).toEqual(['getTime', 'dbops']);
+    expect(new Set(plugins?.map((plugin) => plugin.etag)).size).toBe(2);
+  });
+
+  it('keeps gateway lookup diagnostics when session lookup fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"error":"missing"}', { status: 404 })
+    );
+    const repo = createRepo();
+
+    const [, err] = await repo.getPluginByUserPluginId({
+      pluginId: 'getTime',
+      source: 'debug:user:u1'
+    });
+
+    expect(err).toMatchObject({
+      code: 'connection_gateway.session_not_found',
+      data: {
+        source: 'debug:user:u1',
+        gatewayBaseUrl: 'http://gateway.local',
+        gatewayStatus: 404
+      }
+    });
+  });
+});
+
+function createRepo(): DebugPluginRepoOverlay {
+  return new DebugPluginRepoOverlay({
+    fallback: makeFallbackRepo(),
+    gatewayBaseUrl: 'http://gateway.local',
+    authToken: 'token'
+  });
+}
+
+function makeFallbackRepo(): PluginRepoPort {
+  return {
+    getPendingPluginIds: vi.fn().mockResolvedValue(successResult([])),
+    createPlugin: vi.fn().mockResolvedValue(successResult({})),
+    confirmPlugin: vi.fn(),
+    deletePendingPlugin: vi.fn().mockResolvedValue(successResult({})),
+    getPluginById: vi.fn(),
+    getPluginsByPluginId: vi.fn().mockResolvedValue(successResult([])),
+    getPluginByUserPluginId: vi.fn(),
+    listVersions: vi.fn().mockResolvedValue(successResult([])),
+    list: vi.fn().mockResolvedValue(successResult([])),
+    listToolSummaries: vi.fn().mockResolvedValue(successResult([])),
+    listActive: vi.fn().mockResolvedValue(successResult([])),
+    disablePlugins: vi.fn().mockResolvedValue(successResult({})),
+    pruneDisabled: vi.fn().mockResolvedValue(successResult({ count: 0, plugins: [] })),
+    listTags: vi.fn().mockResolvedValue(successResult([])),
+    getPluginFileAccessURL: vi.fn()
+  } as unknown as PluginRepoPort;
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+}
+
+function makeGatewayStatus() {
+  return {
+    data: {
+      session: {
+        id: 'session-a',
+        sessionScope: {
+          source: 'debug:user:u1'
+        },
+        metadata: {
+          pluginDebug: {
+            targets: [
+              makeMetadata('getTime', '0.1.1'),
+              makeMetadata('dbops', '0.2.0')
+            ]
+          }
+        }
+      }
+    }
+  };
+}
+
+function makeMetadata(pluginId: string, version: string) {
+  return {
+    source: 'debug:user:u1',
+    pluginId,
+    version,
+    name: pluginId,
+    description: `${pluginId} description`,
+    toolDescription: `${pluginId} tool`,
+    tags: ['tools'],
+    permissions: [],
+    secretSchema: {},
+    isToolSet: false,
+    tools: [
+      {
+        id: pluginId,
+        name: pluginId,
+        description: `${pluginId} description`,
+        toolDescription: `${pluginId} tool`,
+        inputSchema: {},
+        outputSchema: {}
+      }
+    ]
+  };
+}

--- a/packages/infrastructure/src/plugin/debug-plugin.repo.ts
+++ b/packages/infrastructure/src/plugin/debug-plugin.repo.ts
@@ -1,0 +1,417 @@
+import { type PluginType, PluginTypeEnum } from '@domain/entities/plugin.entity';
+import { ToolSchema } from '@domain/entities/tool.entity';
+import type {
+  PluginListInputType,
+  PluginListOutputType,
+  PluginRepoPort,
+  PluginVersionListInputType,
+  PluginVersionListOutputType
+} from '@domain/ports/plugin/plugin-repo.port';
+import {
+  PluginListItemSchema,
+  PluginVersionItemSchema
+} from '@domain/ports/plugin/plugin-repo.port';
+import type {
+  ToolListInputType,
+  ToolListOutputType
+} from '@domain/ports/plugin/tool.port';
+import { ToolListItemSchema } from '@domain/ports/plugin/tool.port';
+import { createError } from '@domain/value-objects/error.vo';
+import type { FileObject } from '@domain/value-objects/file/file-object.vo';
+import type { PkgContentFileObjects } from '@domain/value-objects/file/pkg-file.vo';
+import type {
+  PluginSourceType,
+  PluginUniqueIdType,
+  UserPluginIdType
+} from '@domain/value-objects/plugin.vo';
+import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { ErrorCode } from '@infrastructure/errors/error.registry';
+
+type GatewayStatusResponse = {
+  data: {
+    session: {
+      id: string;
+      sessionScope: {
+        source?: string;
+      };
+      metadata?: {
+        pluginDebug?: DebugPluginMetadata | DebugPluginMetadataBundle;
+      };
+    } | null;
+  };
+};
+
+type DebugPluginMetadata = DebugPluginMetadataPayload & {
+  source?: string;
+};
+
+type DebugPluginMetadataPayload = {
+  pluginId: string;
+  version: string;
+  name: string;
+  description: string;
+  toolDescription: string;
+  author?: string;
+  tags?: string[];
+  permissions?: string[];
+  secretSchema?: Record<string, unknown>;
+  isToolSet: boolean;
+  tools: Array<{
+    id: string;
+    name: string;
+    description: string;
+    toolDescription: string;
+    inputSchema: Record<string, unknown>;
+    outputSchema: Record<string, unknown>;
+  }>;
+};
+
+type DebugPluginMetadataBundle = {
+  targets: DebugPluginMetadata[];
+};
+
+export class DebugPluginRepoOverlay implements PluginRepoPort {
+  constructor(
+    private readonly deps: {
+      fallback: PluginRepoPort;
+      gatewayBaseUrl: string;
+      authToken: string;
+    }
+  ) {}
+
+  getPendingPluginIds(): ReturnType<PluginRepoPort['getPendingPluginIds']> {
+    return this.deps.fallback.getPendingPluginIds();
+  }
+
+  createPlugin(arg: { plugin: PluginType; pending?: boolean; files: PkgContentFileObjects }): Promise<Result> {
+    return this.deps.fallback.createPlugin(arg);
+  }
+
+  confirmPlugin(uniqueId: PluginUniqueIdType): Promise<Result<PluginType>> {
+    return this.deps.fallback.confirmPlugin(uniqueId);
+  }
+
+  deletePendingPlugin(uniqueId: PluginUniqueIdType): Promise<Result> {
+    return this.deps.fallback.deletePendingPlugin(uniqueId);
+  }
+
+  getPluginById(
+    uniqueId: PluginUniqueIdType
+  ): Promise<Result<{ info: PluginType; indexFile: FileObject; entryFilePath: string }>> {
+    return this.deps.fallback.getPluginById(uniqueId);
+  }
+
+  getPluginsByPluginId(pluginId: string): Promise<Result<PluginType[]>> {
+    return this.deps.fallback.getPluginsByPluginId(pluginId);
+  }
+
+  async getPluginByUserPluginId(userPluginId: UserPluginIdType): Promise<Result<PluginType>> {
+    if (!isDebugSource(userPluginId.source)) {
+      return this.deps.fallback.getPluginByUserPluginId(userPluginId);
+    }
+
+    const [metadata, err] = await this.getDebugMetadata(userPluginId.source, userPluginId.pluginId);
+    if (err) {
+      return failureResult(err);
+    }
+    if (metadata.pluginId !== userPluginId.pluginId) {
+      return failureResult({
+        en: 'Debug plugin not found',
+        'zh-CN': '调试插件不存在'
+      });
+    }
+
+    return successResult(toPlugin(metadata, userPluginId.source));
+  }
+
+  async listVersions({
+    pluginId,
+    source
+  }: PluginVersionListInputType): Promise<Result<PluginVersionListOutputType>> {
+    if (!isDebugSource(source)) {
+      return this.deps.fallback.listVersions({ pluginId, source });
+    }
+
+    const [metadata, err] = await this.getDebugMetadata(source, pluginId);
+    if (err) {
+      return failureResult(err);
+    }
+    if (metadata.pluginId !== pluginId) {
+      return successResult([]);
+    }
+
+    return successResult([
+      PluginVersionItemSchema.parse({
+        version: metadata.version
+      })
+    ]);
+  }
+
+  async list(arg: PluginListInputType): Promise<Result<PluginListOutputType>> {
+    const debugSources = (arg.sources ?? []).filter(isDebugSource);
+    if (debugSources.length === 0) {
+      return this.deps.fallback.list(arg);
+    }
+
+    const items = await this.listDebugPlugins(debugSources);
+    return successResult(
+      items.map(({ source, metadata }) =>
+        PluginListItemSchema.parse({
+          pluginId: metadata.pluginId,
+          version: metadata.version,
+          etag: toDebugEtag(source, metadata),
+          type: PluginTypeEnum.tool,
+          author: metadata.author,
+          name: toI18n(metadata.name),
+          icon: '',
+          description: toI18n(metadata.description),
+          tags: metadata.tags,
+          source
+        })
+      )
+    );
+  }
+
+  async listToolSummaries(arg: ToolListInputType): Promise<Result<ToolListOutputType>> {
+    const debugSources = (arg.sources ?? []).filter(isDebugSource);
+    if (debugSources.length === 0) {
+      return this.deps.fallback.listToolSummaries(arg);
+    }
+
+    const items = await this.listDebugPlugins(debugSources);
+    return successResult(
+      items.map(({ source, metadata }) =>
+        ToolListItemSchema.parse({
+          pluginId: metadata.pluginId,
+          version: metadata.version,
+          etag: toDebugEtag(source, metadata),
+          type: PluginTypeEnum.tool,
+          author: metadata.author,
+          name: toI18n(metadata.name),
+          icon: '',
+          description: toI18n(metadata.description),
+          tags: metadata.tags,
+          toolDescription: metadata.toolDescription,
+          source,
+          isToolset: metadata.isToolSet,
+          hasSecret: Boolean(
+            metadata.secretSchema?.properties &&
+              Object.keys(metadata.secretSchema.properties as Record<string, unknown>).length > 0
+          ),
+          children: metadata.isToolSet
+            ? metadata.tools.map((tool) => ({
+                id: tool.id,
+                name: toI18n(tool.name),
+                description: toI18n(tool.description),
+                toolDescription: tool.toolDescription
+              }))
+            : undefined
+        })
+      )
+    );
+  }
+
+  listActive(): Promise<Result<PluginType[]>> {
+    return this.deps.fallback.listActive();
+  }
+
+  disablePlugins(uniqueIds: PluginUniqueIdType[]): Promise<Result> {
+    return this.deps.fallback.disablePlugins(uniqueIds);
+  }
+
+  pruneDisabled(): ReturnType<PluginRepoPort['pruneDisabled']> {
+    return this.deps.fallback.pruneDisabled();
+  }
+
+  listTags(): ReturnType<PluginRepoPort['listTags']> {
+    return this.deps.fallback.listTags();
+  }
+
+  getPluginFileAccessURL(
+    uniqueId: PluginUniqueIdType,
+    filePath: string[],
+    pending: boolean
+  ): ReturnType<PluginRepoPort['getPluginFileAccessURL']> {
+    return this.deps.fallback.getPluginFileAccessURL(uniqueId, filePath, pending);
+  }
+
+  private async listDebugPlugins(sources: string[]) {
+    const results = (
+      await Promise.all(
+        sources.map(async (source) => {
+          const [metadata, err] = await this.listDebugMetadata(source);
+          return err ? [] : metadata.map((item) => ({ source, metadata: item }));
+        })
+      )
+    ).flat();
+
+    return results;
+  }
+
+  private async listDebugMetadata(source: string): Promise<Result<DebugPluginMetadata[]>> {
+    const [value, err] = await this.getDebugMetadataValue(source);
+    if (err) {
+      return [null, err];
+    }
+
+    return successResult(pickDebugMetadataList(value, source));
+  }
+
+  private async getDebugMetadata(
+    source: string,
+    pluginId?: string
+  ): Promise<Result<DebugPluginMetadata>> {
+    const [value, err] = await this.getDebugMetadataValue(source);
+    if (err) {
+      return [null, err];
+    }
+
+    const metadata = pickDebugMetadata(value, source, pluginId);
+    if (!metadata) {
+      return failureResult({
+        en: `Debug plugin metadata not found: ${source}`,
+        'zh-CN': `调试插件元数据不存在: ${source}`
+      });
+    }
+
+    return successResult(metadata);
+  }
+
+  private async getDebugMetadataValue(
+    source: string
+  ): Promise<Result<DebugPluginMetadata | DebugPluginMetadataBundle | undefined>> {
+    try {
+      const response = await fetch(
+        `${this.gatewayBaseUrl}/internal/sessions/by-source/${encodeURIComponent(source)}/status`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.deps.authToken}`
+          }
+        }
+      );
+      const text = await response.text();
+      if (!response.ok) {
+        return failureResult(
+          createError(ErrorCode.connectionGatewaySessionNotFound, {
+            message: `Debug plugin session lookup failed: ${source}`,
+            reason: {
+              en: `Debug plugin session lookup failed: ${source}`,
+              'zh-CN': `调试插件会话查询失败: ${source}`
+            },
+            data: {
+              source,
+              gatewayBaseUrl: this.gatewayBaseUrl,
+              gatewayStatus: response.status,
+              gatewayResponse: truncateText(text, 500)
+            }
+          })
+        );
+      }
+
+      const payload = JSON.parse(text) as GatewayStatusResponse;
+      return successResult(payload.data.session?.metadata?.pluginDebug);
+    } catch (error) {
+      return failureResult(
+        {
+          en: 'Failed to get debug plugin metadata',
+          'zh-CN': '获取调试插件元数据失败'
+        },
+        error
+      );
+    }
+  }
+
+  private get gatewayBaseUrl(): string {
+    return this.deps.gatewayBaseUrl.replace(/\/+$/, '');
+  }
+}
+
+function pickDebugMetadataList(
+  value: DebugPluginMetadata | DebugPluginMetadataBundle | undefined,
+  source: string
+): DebugPluginMetadata[] {
+  if (!value) {
+    return [];
+  }
+
+  if ('targets' in value) {
+    return value.targets.filter((target) => target.source === source);
+  }
+
+  return value.source === source ? [value] : [];
+}
+
+function pickDebugMetadata(
+  value: DebugPluginMetadata | DebugPluginMetadataBundle | undefined,
+  source: string,
+  pluginId?: string
+): DebugPluginMetadata | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if ('targets' in value) {
+    return value.targets.find(
+      (target) => target.source === source && (!pluginId || target.pluginId === pluginId)
+    );
+  }
+
+  if (value.source !== source) {
+    return undefined;
+  }
+
+  if (pluginId && value.pluginId !== pluginId) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function toPlugin(metadata: DebugPluginMetadata, source: string): PluginType {
+  return ToolSchema.parse({
+    pluginId: metadata.pluginId,
+    version: metadata.version,
+    etag: toDebugEtag(source, metadata),
+    type: PluginTypeEnum.tool,
+    author: metadata.author,
+    name: toI18n(metadata.name),
+    icon: '',
+    description: toI18n(metadata.description),
+    tags: metadata.tags,
+    permission: metadata.permissions,
+    toolDescription: metadata.toolDescription,
+    secretSchema: metadata.secretSchema,
+    inputSchema: metadata.isToolSet ? undefined : metadata.tools[0]?.inputSchema,
+    outputSchema: metadata.isToolSet ? undefined : metadata.tools[0]?.outputSchema,
+    children: metadata.isToolSet
+      ? metadata.tools.map((tool) => ({
+          id: tool.id,
+          name: toI18n(tool.name),
+          description: toI18n(tool.description),
+          icon: '',
+          toolDescription: tool.toolDescription,
+          inputSchema: tool.inputSchema,
+          outputSchema: tool.outputSchema
+        }))
+      : undefined
+  });
+}
+
+function isDebugSource(source: PluginSourceType | undefined): source is string {
+  return typeof source === 'string' && source.startsWith('debug:');
+}
+
+function toI18n(value: string) {
+  return {
+    en: value,
+    'zh-CN': value
+  };
+}
+
+function toDebugEtag(source: string, metadata: Pick<DebugPluginMetadata, 'pluginId' | 'version'>): string {
+  return `debug-${Buffer.from(`${source}:${metadata.pluginId}:${metadata.version}`).toString('base64url').slice(0, 24)}`;
+}

--- a/packages/infrastructure/src/plugin/plugin-runtime/composite-runtime.manager.ts
+++ b/packages/infrastructure/src/plugin/plugin-runtime/composite-runtime.manager.ts
@@ -1,0 +1,74 @@
+import type { PluginRuntimeConfigType } from '@domain/entities/plugin.entity';
+import type {
+  PluginInvokeEventNameType,
+  PluginRuntimeInvokeOptions,
+  PluginRuntimeManagerPort
+} from '@domain/ports/plugin/plugin-runtime-manager.port';
+import type { PluginUniqueIdType } from '@domain/value-objects/plugin.vo';
+import type { Result } from '@domain/value-objects/result.vo';
+import type { StreamData } from '@domain/value-objects/stream.vo';
+
+export class CompositePluginRuntimeManager<Config extends PluginRuntimeConfigType = PluginRuntimeConfigType>
+  implements PluginRuntimeManagerPort<Config>
+{
+  constructor(
+    private readonly deps: {
+      primary: PluginRuntimeManagerPort<Config>;
+      debug: PluginRuntimeManagerPort<PluginRuntimeConfigType>;
+    }
+  ) {}
+
+  register(uniqueId: PluginUniqueIdType, options?: unknown): Promise<Result> {
+    return this.deps.primary.register(uniqueId, options as never);
+  }
+
+  unregister(
+    uniqueId: PluginUniqueIdType,
+    options?: { replacementUniqueId?: PluginUniqueIdType }
+  ): Promise<Result> {
+    return this.deps.primary.unregister(uniqueId, options);
+  }
+
+  getConfig(pluginId: string): Promise<Result<Config>> {
+    return this.deps.primary.getConfig(pluginId);
+  }
+
+  updateConfig(pluginId: string, config: Config): Promise<Result> {
+    return this.deps.primary.updateConfig(pluginId, config);
+  }
+
+  resetConfig(pluginId: string): Promise<Result> {
+    return this.deps.primary.resetConfig(pluginId);
+  }
+
+  status(uniqueId: PluginUniqueIdType): Promise<Result<unknown>> {
+    return this.deps.primary.status(uniqueId);
+  }
+
+  globalStatus(): Promise<Result<unknown>> {
+    return this.deps.primary.globalStatus();
+  }
+
+  shutdown(timeout?: number): Promise<Result> {
+    return this.deps.primary.shutdown(timeout);
+  }
+
+  invoke<
+    R = unknown,
+    S extends boolean = boolean,
+    E extends PluginInvokeEventNameType = PluginInvokeEventNameType,
+    P = unknown
+  >(arg0: {
+    uniqueId: PluginUniqueIdType;
+    eventName: E;
+    payload: P;
+    returnStream: S;
+    options?: PluginRuntimeInvokeOptions;
+  }): Promise<Result<S extends true ? StreamData<R> : R>> {
+    if (arg0.options?.debug) {
+      return this.deps.debug.invoke(arg0) as Promise<Result<S extends true ? StreamData<R> : R>>;
+    }
+
+    return this.deps.primary.invoke(arg0);
+  }
+}

--- a/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.test.ts
+++ b/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.test.ts
@@ -1,0 +1,143 @@
+import '@infrastructure/errors/error.registry';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ToolStreamMessageType } from '@domain/value-objects/tool.vo';
+
+import { ConnectionGatewayDebugRuntimeManager } from './debug-runtime.driver';
+
+describe('ConnectionGatewayDebugRuntimeManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes a debug session through gateway response streams', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            session: {
+              id: 'session-a',
+              consumerType: 'plugin-debug',
+              generation: 0
+            }
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        ndjsonResponse([
+          {
+            protocol: 'connection-gateway.v1',
+            sessionId: 'session-a',
+            generation: 0,
+            requestId: 'invoke-a',
+            type: 'response',
+            consumerType: 'plugin-debug',
+            capability: 'invoke',
+            createdAt: Date.now(),
+            payload: { kind: 'plugin-debug.accepted' }
+          },
+          {
+            protocol: 'connection-gateway.v1',
+            sessionId: 'session-a',
+            generation: 0,
+            requestId: 'invoke-a',
+            type: 'stream',
+            consumerType: 'plugin-debug',
+            capability: 'invoke',
+            createdAt: Date.now(),
+            payload: {
+              kind: 'plugin-debug.stream',
+              event: 'chunk',
+              data: { type: 'response', data: { time: 'now' } }
+            }
+          },
+          {
+            protocol: 'connection-gateway.v1',
+            sessionId: 'session-a',
+            generation: 0,
+            requestId: 'invoke-a',
+            type: 'stream',
+            consumerType: 'plugin-debug',
+            capability: 'invoke',
+            createdAt: Date.now(),
+            payload: {
+              kind: 'plugin-debug.stream',
+              event: 'end'
+            }
+          }
+        ])
+      );
+    const manager = new ConnectionGatewayDebugRuntimeManager({
+      baseUrl: 'http://gateway.local',
+      authToken: 'token',
+      requestTimeoutMs: 1_000,
+      sourceForUser: ({ userId }) => `debug:user:${userId}`
+    });
+
+    const [stream, err] = await manager.invoke<ToolStreamMessageType, true>({
+      uniqueId: {
+        pluginId: 'getTime',
+        version: '1.0.0',
+        etag: 'debug'
+      },
+      eventName: 'run',
+      payload: {
+        input: {},
+        systemVar: {
+          app: { id: 'app', name: 'app' },
+          chat: { chatId: 'chat' },
+          invokeToken: 'token',
+          time: 'now'
+        }
+      },
+      returnStream: true,
+      options: {
+        invocationId: 'invoke-a',
+        debug: {
+          userId: 'u1'
+        }
+      }
+    });
+
+    expect(err).toBeNull();
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://gateway.local/internal/sessions/by-source/debug%3Auser%3Au1/status',
+      expect.any(Object)
+    );
+    expect(JSON.parse(vi.mocked(fetch).mock.calls[1]?.[1]?.body as string)).toMatchObject({
+      envelope: {
+        payload: {
+          payload: {
+            pluginId: 'getTime',
+            source: 'debug:user:u1'
+          }
+        }
+      }
+    });
+    const messages: ToolStreamMessageType[] = [];
+    await stream?.consume((message) => {
+      messages.push(message);
+    });
+    expect(messages).toEqual([{ type: 'response', data: { time: 'now' } }]);
+  });
+});
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+}
+
+function ndjsonResponse(payloads: unknown[]): Response {
+  return new Response(payloads.map((payload) => JSON.stringify(payload)).join('\n'), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/x-ndjson'
+    }
+  });
+}

--- a/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.ts
+++ b/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.ts
@@ -1,0 +1,307 @@
+import type { PluginRuntimeConfigType } from '@domain/entities/plugin.entity';
+import type {
+  PluginInvokeEventNameType,
+  PluginRuntimeInvokeOptions,
+  PluginRuntimeManagerPort
+} from '@domain/ports/plugin/plugin-runtime-manager.port';
+import type { ConnectionGatewayEnvelope } from '@domain/value-objects/connection-gateway.vo';
+import {
+  CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE,
+  CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+  ConnectionGatewayPluginDebugResponsePayloadSchema,
+  ConnectionGatewayPluginDebugStreamPayloadSchema
+} from '@domain/value-objects/connection-gateway-debug.vo';
+import { createError } from '@domain/value-objects/error.vo';
+import type { PluginUniqueIdType } from '@domain/value-objects/plugin.vo';
+import { failureResult, type Result, successResult } from '@domain/value-objects/result.vo';
+import { StreamData } from '@domain/value-objects/stream.vo';
+import { ErrorCode } from '@infrastructure/errors/error.registry';
+
+export type ConnectionGatewayDebugRuntimeManagerOptions = {
+  baseUrl: string;
+  authToken: string;
+  requestTimeoutMs: number;
+  sourceForUser(input: { userId: string }): string;
+};
+
+export type ConnectionGatewayDebugRuntimeInvokeOptions = PluginRuntimeInvokeOptions & {
+  debug?: {
+    userId: string;
+    source?: string;
+  };
+};
+
+export class ConnectionGatewayDebugRuntimeManager
+  implements PluginRuntimeManagerPort<PluginRuntimeConfigType, unknown>
+{
+  constructor(private readonly options: ConnectionGatewayDebugRuntimeManagerOptions) {}
+
+  async register(): Promise<Result> {
+    return successResult({});
+  }
+
+  async unregister(): Promise<Result> {
+    return successResult({});
+  }
+
+  async getConfig(): Promise<Result<PluginRuntimeConfigType>> {
+    return successResult({});
+  }
+
+  async updateConfig(): Promise<Result> {
+    return successResult({});
+  }
+
+  async resetConfig(): Promise<Result> {
+    return successResult({});
+  }
+
+  async status(): Promise<Result<unknown>> {
+    return successResult({});
+  }
+
+  async globalStatus(): Promise<Result<unknown>> {
+    return successResult({});
+  }
+
+  async shutdown(): Promise<Result> {
+    return successResult({});
+  }
+
+  async invoke<
+    R = unknown,
+    S extends boolean = boolean,
+    E extends PluginInvokeEventNameType = PluginInvokeEventNameType,
+    P = unknown
+  >({
+    uniqueId,
+    eventName,
+    payload,
+    returnStream,
+    options
+  }: {
+    uniqueId: PluginUniqueIdType;
+    eventName: E;
+    payload: P;
+    returnStream: S;
+    options?: ConnectionGatewayDebugRuntimeInvokeOptions;
+  }): Promise<Result<S extends true ? StreamData<R> : R>> {
+    if (eventName !== 'run' || !returnStream) {
+      return failureResult(createError(ErrorCode.pluginRuntimeEventNotSupported));
+    }
+
+    const debugUserId = options?.debug?.userId;
+    if (!debugUserId) {
+      return failureResult(
+        createError(ErrorCode.pluginRuntimePluginNotFound, {
+          message: 'Missing debug user id for connection-gateway runtime'
+        })
+      );
+    }
+
+    try {
+      const source =
+        options.debug?.source ??
+        this.options.sourceForUser({
+          userId: debugUserId
+        });
+      const session = await this.findSessionBySource(source);
+      const responses = this.publishRequestAndReadStream({
+        session,
+        invocationId: options?.invocationId,
+        timeoutMs: options?.timeout ?? this.options.requestTimeoutMs,
+        source,
+        pluginId: uniqueId.pluginId,
+        payload
+      });
+
+      return successResult(
+        StreamData.create<R>((stream) => {
+          void consumeGatewayResponses(responses, stream).catch((error) => {
+            stream.fail(error instanceof Error ? error : new Error(String(error)));
+          });
+        }) as S extends true ? StreamData<R> : R
+      );
+    } catch (error) {
+      return failureResult(
+        createError(ErrorCode.pluginInvokeFailed, {
+          cause: error
+        })
+      );
+    }
+  }
+
+  private async findSessionBySource(source: string): Promise<GatewayDebugSession> {
+    const status = await this.getJson<GatewayStatusResponse>(
+      `/internal/sessions/by-source/${encodeURIComponent(source)}/status`
+    );
+    const session = status.data.session;
+
+    if (!session || session.consumerType !== CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE) {
+      throw createError(ErrorCode.connectionGatewaySessionNotFound, {
+        data: { source }
+      });
+    }
+
+    return session;
+  }
+
+  private async *publishRequestAndReadStream({
+    session,
+    invocationId,
+    timeoutMs,
+    source,
+    pluginId,
+    payload
+  }: {
+    session: GatewayDebugSession;
+    invocationId?: string;
+    timeoutMs: number;
+    source: string;
+    pluginId: string;
+    payload: unknown;
+  }): AsyncIterable<ConnectionGatewayEnvelope> {
+    const response = await fetch(
+      `${this.baseUrl}/internal/sessions/${encodeURIComponent(session.id)}/requests:stream`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.options.authToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          timeoutMs,
+          envelope: {
+            protocol: 'connection-gateway.v1',
+            sessionId: session.id,
+            generation: session.generation,
+            requestId: invocationId,
+            type: 'request',
+            consumerType: session.consumerType,
+            capability: CONNECTION_GATEWAY_PLUGIN_DEBUG_INVOKE_CAPABILITY,
+            createdAt: Date.now(),
+            payload: {
+              kind: 'plugin-debug.run',
+              eventName: 'run',
+              payload: {
+                ...toObjectPayload(payload),
+                pluginId,
+                source
+              }
+            }
+          }
+        })
+      }
+    );
+
+    if (!response.ok || !response.body) {
+      const text = await response.text();
+      throw new Error(`Gateway stream request failed: ${response.status} ${text}`);
+    }
+
+    yield* readNdjsonEnvelopes(response.body);
+  }
+
+  private async getJson<T>(path: string): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      headers: {
+        Authorization: `Bearer ${this.options.authToken}`
+      }
+    });
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw new Error(`Gateway request failed: ${response.status} ${text}`);
+    }
+
+    return JSON.parse(text) as T;
+  }
+
+  private get baseUrl(): string {
+    return this.options.baseUrl.replace(/\/+$/, '');
+  }
+}
+
+function toObjectPayload(payload: unknown): Record<string, unknown> {
+  return payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : {};
+}
+
+type GatewayDebugSession = {
+  id: string;
+  consumerType: string;
+  generation: number;
+};
+
+type GatewayStatusResponse = {
+  data: {
+    session: GatewayDebugSession | null;
+  };
+};
+
+async function consumeGatewayResponses<R>(
+  responses: AsyncIterable<ConnectionGatewayEnvelope>,
+  stream: StreamData<R>
+): Promise<void> {
+  for await (const envelope of responses) {
+    if (envelope.type === 'response') {
+      const response = ConnectionGatewayPluginDebugResponsePayloadSchema.parse(envelope.payload);
+      if (response.kind === 'plugin-debug.error') {
+        throw new Error(response.message);
+      }
+      continue;
+    }
+
+    if (envelope.type !== 'stream') {
+      continue;
+    }
+
+    const frame = ConnectionGatewayPluginDebugStreamPayloadSchema.parse(envelope.payload);
+    if (frame.event === 'chunk') {
+      stream.write(frame.data as R);
+      continue;
+    }
+
+    if (frame.event === 'error') {
+      throw new Error(frame.message);
+    }
+
+    stream.close();
+    return;
+  }
+
+  stream.close();
+}
+
+async function* readNdjsonEnvelopes(body: ReadableStream<Uint8Array>): AsyncIterable<ConnectionGatewayEnvelope> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+
+    while (true) {
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex < 0) {
+        break;
+      }
+
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (line) {
+        yield JSON.parse(line) as ConnectionGatewayEnvelope;
+      }
+    }
+
+    if (done) {
+      const trailing = buffer.trim();
+      if (trailing) {
+        yield JSON.parse(trailing) as ConnectionGatewayEnvelope;
+      }
+      return;
+    }
+  }
+}

--- a/packages/infrastructure/src/plugin/tool.impl.ts
+++ b/packages/infrastructure/src/plugin/tool.impl.ts
@@ -210,7 +210,15 @@ export class ToolManager implements ToolManagerPort {
       invoke: new InvokeManager({
         token: this.getInvokeToken(systemVar),
         fastgptBaseUrl: this.deps.fastgptBaseUrl
-      })
+      }),
+      ...(isDebugPluginSource(source)
+        ? {
+            debug: {
+              userId: getDebugUserIdFromSource(source),
+              source
+            }
+          }
+        : {})
     };
 
     const [invokeRes, invokeErr] = await this.deps.pluginRuntimeManager.invoke<
@@ -242,6 +250,25 @@ export class ToolManager implements ToolManagerPort {
 
     return successResult(invokeRes);
   }
+}
+
+function isDebugPluginSource(source: PluginSourceType | undefined): source is string {
+  return typeof source === 'string' && source.startsWith('debug:');
+}
+
+function getDebugUserIdFromSource(source: string): string {
+  const parts = source.split(':');
+  const userIndex = parts.indexOf('user');
+  const userId = userIndex >= 0 ? parts[userIndex + 1] : undefined;
+
+  if (!userId) {
+    throw createError(ErrorCode.pluginRuntimePluginNotFound, {
+      message: 'Debug source must include user id',
+      data: { source }
+    });
+  }
+
+  return userId;
 }
 
 type ToolRunErrorContext = {

--- a/packages/infrastructure/src/redis/redis-client.ts
+++ b/packages/infrastructure/src/redis/redis-client.ts
@@ -42,12 +42,12 @@ export const FASTGPT_REDIS_PREFIX = 'fastgpt-plugin:';
 
 /** Redis 底层连接类，单例模式 */
 export class RedisClient {
-  private static readonly instance = new RedisClient();
+  private static instance: RedisClient | undefined;
   private client: Redis;
   private readonly logger = getLogger(infra.redis);
 
-  private constructor() {
-    this.client = new Redis(env.REDIS_URL, {
+  private constructor(redisUrl: string) {
+    this.client = new Redis(redisUrl, {
       ...REDIS_BASE_OPTION,
       keyPrefix: FASTGPT_REDIS_PREFIX
     });
@@ -65,7 +65,12 @@ export class RedisClient {
   }
 
   static getInstance(): RedisClient {
+    RedisClient.instance ??= new RedisClient(env.REDIS_URL);
     return RedisClient.instance;
+  }
+
+  static create({ redisUrl }: { redisUrl: string }): RedisClient {
+    return new RedisClient(redisUrl);
   }
 
   async getAllKeysByPrefix(key: string): Promise<string[]> {

--- a/packages/infrastructure/src/utils/proxy/index.ts
+++ b/packages/infrastructure/src/utils/proxy/index.ts
@@ -2,12 +2,19 @@ import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 
 import { env } from '../../env';
 
-export function configureProxy() {
+type ProxyEnv = {
+  HTTP_PROXY?: string;
+  HTTPS_PROXY?: string;
+  NO_PROXY?: string;
+  ALL_PROXY?: string;
+};
+
+export function configureProxy(runtimeEnv: ProxyEnv = env) {
   const agent = new EnvHttpProxyAgent();
   setGlobalDispatcher(agent);
 
-  console.info('✓ HTTP_PROXY: %s', env.HTTP_PROXY);
-  console.info('✓ HTTPS_PROXY: %s', env.HTTPS_PROXY);
-  console.info('✓ NO_PROXY: %s', env.NO_PROXY);
-  console.info('✓ ALL_PROXY: %s', env.ALL_PROXY);
+  console.info('✓ HTTP_PROXY: %s', runtimeEnv.HTTP_PROXY);
+  console.info('✓ HTTPS_PROXY: %s', runtimeEnv.HTTPS_PROXY);
+  console.info('✓ NO_PROXY: %s', runtimeEnv.NO_PROXY);
+  console.info('✓ ALL_PROXY: %s', runtimeEnv.ALL_PROXY);
 }

--- a/packages/interface-adapter/src/contracts/dto/connection-gateway.dto.ts
+++ b/packages/interface-adapter/src/contracts/dto/connection-gateway.dto.ts
@@ -10,7 +10,8 @@ import {
 
 export const ConnectionGatewayCreateSessionRequestDTOSchema = z.object({
   token: z.string().min(1),
-  transport: z.enum(['tcp', 'websocket'])
+  transport: z.enum(['tcp', 'websocket']),
+  metadata: z.record(z.string(), z.unknown()).optional()
 });
 export type ConnectionGatewayCreateSessionRequestDTO = z.infer<
   typeof ConnectionGatewayCreateSessionRequestDTOSchema
@@ -28,6 +29,14 @@ export const ConnectionGatewayRequestDTOSchema = z.object({
   stream: z.boolean().default(false)
 });
 export type ConnectionGatewayRequestDTO = z.infer<typeof ConnectionGatewayRequestDTOSchema>;
+
+export const ConnectionGatewayStreamRequestDTOSchema = z.object({
+  envelope: ConnectionGatewayEnvelopeSchema,
+  timeoutMs: z.number().int().positive().optional()
+});
+export type ConnectionGatewayStreamRequestDTO = z.infer<
+  typeof ConnectionGatewayStreamRequestDTOSchema
+>;
 
 export const ConnectionGatewayRequestAcceptedDTOSchema = z.object({
   messageId: z.string(),


### PR DESCRIPTION
## Summary
- Add a TCP-backed connection gateway debug channel for local plugin debugging.
- Add debug session/source routing so one debug channel can serve multiple plugin targets.
- Split server and gateway env access so gateway startup only requires gateway-side auth config.
- Fix Redis mailbox blocking latency by using dedicated blocking connections, and refresh session index TTLs on renewal/status changes.
- Add connection-gateway Docker/env template updates and server/gateway env template guidance.

## Test plan
- [x] `pnpm exec vitest run packages/infrastructure/src/env/index.test.ts packages/infrastructure/src/connection-gateway/mailbox.test.ts packages/infrastructure/src/connection-gateway/session-registry.test.ts packages/infrastructure/src/connection-gateway/service.test.ts packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.test.ts --pool=forks` (25 tests)
- [x] `pnpm exec tsc --noEmit --pretty false --incremental false`
- [x] `pnpm exec eslint apps/cli/src/commands/debug.ts apps/cli/src/commands/debug.spec.ts apps/cli/src/debug/gateway.ts apps/connection-gateway/main.ts apps/connection-gateway/src/deps.ts apps/connection-gateway/src/routes.ts apps/server/main.ts apps/server/src/deps.ts packages/domain/src/ports/connection-gateway/mailbox.port.ts packages/domain/src/ports/connection-gateway/session-registry.port.ts packages/domain/src/ports/plugin/plugin-runtime-manager.port.ts packages/domain/src/value-objects/connection-gateway.vo.ts packages/domain/src/value-objects/connection-gateway-debug.vo.ts packages/infrastructure/src/connection-gateway/mailbox.ts packages/infrastructure/src/connection-gateway/mailbox.test.ts packages/infrastructure/src/connection-gateway/service.ts packages/infrastructure/src/connection-gateway/service.test.ts packages/infrastructure/src/connection-gateway/session-registry.ts packages/infrastructure/src/connection-gateway/session-registry.test.ts packages/infrastructure/src/env/index.ts packages/infrastructure/src/env/index.test.ts packages/infrastructure/src/hono/middleware/auth.ts packages/infrastructure/src/logger/index.ts packages/infrastructure/src/metrics/index.ts packages/infrastructure/src/plugin/tool.impl.ts packages/infrastructure/src/plugin/debug-plugin.repo.ts packages/infrastructure/src/plugin/debug-plugin.repo.test.ts packages/infrastructure/src/plugin/plugin-runtime/composite-runtime.manager.ts packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway packages/infrastructure/src/redis/redis-client.ts packages/infrastructure/src/utils/proxy/index.ts packages/interface-adapter/src/contracts/dto/connection-gateway.dto.ts`
- [x] `git diff --check upstream/dev/tcp-debug...HEAD`

## Notes
- Vitest still prints existing local warnings for missing `.env.test` and `.env.test.local`; tests pass.