### PR TITLE
fix: harden connection gateway debug lifecycle

### DIFF
--- a/apps/cli/README.en.md
+++ b/apps/cli/README.en.md
@@ -25,8 +25,25 @@ Command-line tool for FastGPT plugin development. It is used to create, build, t
 - **Local debugging**
   - Provides the `debug` command to inspect plugin and child-tool information.
   - Supports running tools directly, passing input/secrets/systemVar files, and simulating `uploadFile` with a local directory.
+  - Supports a Connection Gateway TCP remote-debug channel, including multiple local plugins mounted on one channel.
 - **Packaging**
   - Provides the `pack` command to package `dist` artifacts into an uploadable `.pkg`.
+
+### Remote Debugging
+
+Local plugins can connect to a test-environment plugin-server through Connection Gateway. The CLI needs the gateway TCP endpoint for the long-lived channel; the HTTP endpoint is used to create and clean up the session.
+
+```bash
+fastgpt-plugin debug ./plugins/getTime ./plugins/dbops \
+  --gateway \
+  --gateway-base-url https://connection-gateway.example.com \
+  --gateway-tcp-url tcp://connection-gateway-tcp.example.com:3012 \
+  --gateway-auth-token "$CONNECTION_GATEWAY_AUTH_TOKEN" \
+  --gateway-jwt-secret "$JWT_SECRET" \
+  --gateway-user-id u1
+```
+
+The default source is `debug:user:{userId}`. One CLI process creates one TCP channel and mounts all plugin entries passed to the command. Reconnect is enabled by default, and a normal shutdown deletes the gateway session. Use `--gateway-no-reconnect` to disable reconnect.
 
 ### TODO
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -25,8 +25,25 @@ FastGPT 插件开发的命令行工具，用于创建、构建和测试 FastGPT 
 - **本地调试**
   - 提供 `debug` 命令查看插件和子工具信息
   - 支持直接运行工具、传入 input/secrets/systemVar 文件，并用本地目录模拟 `uploadFile`
+  - 支持通过 Connection Gateway 建立一个 TCP 远程调试通道，并在一个通道内挂载多个本地插件
 - **打包**
   - 提供 `pack` 命令把 `dist` 产物打成可上传的 `.pkg`
+
+### 远程调试
+
+本地插件可以通过 Connection Gateway 接入测试环境的 plugin-server。CLI 只需要能访问 gateway 的 TCP 地址；HTTP 地址用于创建/清理 session。
+
+```bash
+fastgpt-plugin debug ./plugins/getTime ./plugins/dbops \
+  --gateway \
+  --gateway-base-url https://connection-gateway.example.com \
+  --gateway-tcp-url tcp://connection-gateway-tcp.example.com:3012 \
+  --gateway-auth-token "$CONNECTION_GATEWAY_AUTH_TOKEN" \
+  --gateway-jwt-secret "$JWT_SECRET" \
+  --gateway-user-id u1
+```
+
+默认 source 为 `debug:user:{userId}`，同一个 CLI 进程会建立 1 个 TCP 通道并挂载所有传入的插件。断线后默认自动重连，正常退出时会清理 gateway session；如需关闭自动重连，可加 `--gateway-no-reconnect`。
 
 ### 待实现 / TODO
 

--- a/apps/cli/src/commands/debug.spec.ts
+++ b/apps/cli/src/commands/debug.spec.ts
@@ -198,6 +198,44 @@ describe('debug command', () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it('默认开启 Connection Gateway 自动重连', async () => {
+    await run([
+      process.execPath,
+      'cli',
+      'debug',
+      GETTIME_TOOL_DIR,
+      '--gateway',
+      '--gateway-user-id',
+      'u1'
+    ]);
+
+    expect(vi.mocked(connectDebugGateway).mock.calls[0]?.[0].options).toMatchObject({
+      reconnect: true,
+      reconnectIntervalMs: 2000
+    });
+    expect(loggerSpy.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('应能关闭 Connection Gateway 自动重连', async () => {
+    await run([
+      process.execPath,
+      'cli',
+      'debug',
+      GETTIME_TOOL_DIR,
+      '--gateway',
+      '--gateway-user-id',
+      'u1',
+      '--gateway-no-reconnect'
+    ]);
+
+    expect(vi.mocked(connectDebugGateway).mock.calls[0]?.[0].options).toMatchObject({
+      reconnect: false
+    });
+    expect(loggerSpy.error).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it('应能在一个 CLI 进程内为多个插件建立远程调试通道', async () => {
     await run([
       process.execPath,

--- a/apps/cli/src/commands/debug.ts
+++ b/apps/cli/src/commands/debug.ts
@@ -41,6 +41,9 @@ type DebugCommandOptions = {
   gatewaySource?: string;
   gatewaySubject?: string;
   gatewayTokenTtlMs?: string;
+  gatewayReconnect?: boolean;
+  gatewayNoReconnect?: boolean;
+  gatewayReconnectIntervalMs?: string;
 };
 
 export class DebugCommand extends BaseCommand {
@@ -69,6 +72,9 @@ export class DebugCommand extends BaseCommand {
       .option('--gateway-source <source>', 'debug source，建议包含 user 维度')
       .option('--gateway-subject <subject>', 'debug session subject')
       .option('--gateway-token-ttl-ms <ms>', 'connection token TTL')
+      .option('--gateway-reconnect', 'Connection Gateway 断线后自动重连', true)
+      .option('--gateway-no-reconnect', '关闭 Connection Gateway 自动重连')
+      .option('--gateway-reconnect-interval-ms <ms>', 'Connection Gateway 重连间隔')
       .action(async (entries: string[], opts: DebugCommandOptions) => {
         await this.run(entries, opts);
       });
@@ -258,6 +264,13 @@ export class DebugCommand extends BaseCommand {
       tokenTtlMs: toPositiveInt(
         options.gatewayTokenTtlMs ?? process.env.CONNECTION_GATEWAY_TOKEN_TTL_MS ?? '300000',
         'gateway-token-ttl-ms'
+      ),
+      reconnect: options.gatewayNoReconnect ? false : options.gatewayReconnect ?? true,
+      reconnectIntervalMs: toPositiveInt(
+        options.gatewayReconnectIntervalMs ??
+          process.env.CONNECTION_GATEWAY_RECONNECT_INTERVAL_MS ??
+          '2000',
+        'gateway-reconnect-interval-ms'
       )
     };
   }

--- a/apps/cli/src/debug/gateway.spec.ts
+++ b/apps/cli/src/debug/gateway.spec.ts
@@ -1,0 +1,202 @@
+import { EventEmitter } from 'node:events';
+import net from 'node:net';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { connectDebugGateway } from './gateway';
+
+describe('connectDebugGateway', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fetchMock.mockReset();
+  });
+
+  it('cleans up the gateway session when the client closes', async () => {
+    const receivedFrames: unknown[] = [];
+    const connectSpy = vi.spyOn(net, 'connect');
+    connectSpy.mockImplementation(
+      ((_port: number, _host: string, connectListener?: () => void) => {
+        const socket = new FakeSocket((chunk) => {
+          receivedFrames.push(...decodeFrames(chunk));
+        });
+        queueMicrotask(() => {
+          connectListener?.();
+        });
+        return socket as unknown as net.Socket;
+      }) as typeof net.connect
+    );
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: { session: makeSession() } }))
+      .mockResolvedValueOnce(jsonResponse({ data: { deleted: true } }));
+
+    const client = await connectDebugGateway({
+      targets: [makeTarget()],
+      options: makeOptions()
+    });
+
+    client.close();
+    await client.closed;
+
+    expect(receivedFrames).toEqual([
+      expect.objectContaining({
+        type: 'event',
+        capability: 'gateway.bind',
+        sessionId: 'session-a'
+      })
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://gateway.local/internal/sessions/session-a',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: {
+          Authorization: 'Bearer gateway-token'
+        }
+      })
+    );
+  });
+
+  it('cleans up the gateway session when tcp connect fails', async () => {
+    const connectError = new Error('tcp unavailable');
+    const connectSpy = vi.spyOn(net, 'connect');
+    connectSpy.mockImplementation(
+      ((_port: number, _host: string, _connectListener?: () => void) => {
+        const socket = new FakeSocket(() => undefined);
+        queueMicrotask(() => {
+          socket.emit('error', connectError);
+        });
+        return socket as unknown as net.Socket;
+      }) as typeof net.connect
+    );
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ data: { session: makeSession() } }))
+      .mockResolvedValueOnce(jsonResponse({ data: { deleted: true } }));
+
+    await expect(
+      connectDebugGateway({
+        targets: [makeTarget()],
+        options: makeOptions()
+      })
+    ).rejects.toThrow('tcp unavailable');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://gateway.local/internal/sessions/session-a',
+      expect.objectContaining({
+        method: 'DELETE'
+      })
+    );
+  });
+});
+
+class FakeSocket extends EventEmitter {
+  constructor(private readonly onWrite: (chunk: Buffer) => void) {
+    super();
+  }
+
+  write(chunk: Buffer, callback?: (error?: Error) => void): boolean {
+    this.onWrite(chunk);
+    callback?.();
+    return true;
+  }
+
+  end(): this {
+    this.emit('close');
+    return this;
+  }
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+}
+
+function makeOptions() {
+  return {
+    baseUrl: 'http://gateway.local',
+    authToken: 'gateway-token',
+    jwtSecret: 'jwt-secret',
+    tcpHost: '127.0.0.1',
+    tcpPort: 3011,
+    userId: 'u1',
+    tokenTtlMs: 30_000,
+    reconnect: false
+  };
+}
+
+function makeTarget() {
+  return {
+    runtime: {} as never,
+    snapshot: {
+      entryDir: '/tmp/plugin',
+      indexPath: '/tmp/plugin/index.ts',
+      pluginId: 'getTime',
+      version: '1.0.0',
+      name: 'getTime',
+      description: 'Get time',
+      toolDescription: 'Get time',
+      tags: [],
+      permissions: [],
+      secretSchema: {},
+      isToolSet: false,
+      tools: []
+    }
+  };
+}
+
+function makeSession() {
+  return {
+    id: 'session-a',
+    consumerType: 'plugin-debug',
+    subject: 'user:u1',
+    sessionScope: {
+      userId: 'u1',
+      source: 'debug:user:u1'
+    },
+    transport: 'tcp',
+    capabilities: ['invoke'],
+    generation: 0,
+    ownerNodeId: 'node-a',
+    status: 'connecting',
+    connectedAt: Date.now(),
+    lastSeenAt: Date.now(),
+    expiresAt: Date.now() + 30_000
+  };
+}
+
+function decodeFrames(chunk: Buffer): unknown[] {
+  const frames: unknown[] = [];
+  let buffer = chunk;
+
+  while (buffer.length > 0) {
+    const headerEnd = buffer.indexOf('\r\n\r\n');
+    if (headerEnd < 0) {
+      return frames;
+    }
+
+    const header = buffer.subarray(0, headerEnd).toString('utf8');
+    const contentLength = Number(
+      header
+        .split(/\r?\n/)
+        .find((line) => line.toLowerCase().startsWith('content-length:'))
+        ?.split(':')[1]
+        ?.trim()
+    );
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + contentLength;
+    frames.push(JSON.parse(buffer.subarray(bodyStart, bodyEnd).toString('utf8')));
+    buffer = buffer.subarray(bodyEnd);
+  }
+
+  return frames;
+}

--- a/apps/cli/src/debug/gateway.ts
+++ b/apps/cli/src/debug/gateway.ts
@@ -34,6 +34,7 @@ export type DebugGatewayClientOptions = {
   subject?: string;
   tokenTtlMs: number;
   reconnect?: boolean;
+  reconnectIntervalMs?: number;
 };
 
 export type DebugGatewayTarget = {
@@ -60,18 +61,99 @@ export async function connectDebugGateway({
     throw new Error('Gateway debug targets cannot be empty');
   }
 
+  if (options.reconnect) {
+    return connectReconnectingDebugGateway({ targets, options, onLog });
+  }
+
+  return connectSingleDebugGateway({ targets, options, onLog });
+}
+
+async function connectReconnectingDebugGateway({
+  targets,
+  options,
+  onLog
+}: {
+  targets: DebugGatewayTarget[];
+  options: DebugGatewayClientOptions;
+  onLog?: (message: string) => void;
+}): Promise<DebugGatewayClient> {
+  let closed = false;
+  let current: DebugGatewayClient | null = null;
+  let currentSession: ConnectionGatewaySession | null = null;
+  const intervalMs = Math.max(100, options.reconnectIntervalMs ?? 2_000);
+
+  const closedPromise = (async () => {
+    while (!closed) {
+      try {
+        current = await connectSingleDebugGateway({ targets, options, onLog });
+        currentSession = current.session;
+        await current.closed;
+      } catch (error) {
+        if (closed) {
+          return;
+        }
+
+        onLog?.(`Connection Gateway 调试通道断开: ${formatErrorMessage(error)}`);
+      } finally {
+        current = null;
+      }
+
+      if (!closed) {
+        onLog?.(`将在 ${intervalMs}ms 后重连 Connection Gateway。`);
+        await delay(intervalMs);
+      }
+    }
+  })();
+
+  while (!currentSession && !closed) {
+    await delay(10);
+  }
+
+  if (!currentSession) {
+    throw new Error('Connection Gateway debug session was closed before connecting');
+  }
+
+  return {
+    session: currentSession,
+    close() {
+      closed = true;
+      current?.close();
+    },
+    closed: closedPromise
+  };
+}
+
+async function connectSingleDebugGateway({
+  targets,
+  options,
+  onLog
+}: {
+  targets: DebugGatewayTarget[];
+  options: DebugGatewayClientOptions;
+  onLog?: (message: string) => void;
+}): Promise<DebugGatewayClient> {
   const session = await createGatewaySession(targets, options);
-  const socket = await connectTcp(options.tcpHost, options.tcpPort);
+  const socket = await connectTcp(options.tcpHost, options.tcpPort).catch(async (error) => {
+    await deleteGatewaySession(session, options).catch((cleanupError) => {
+      onLog?.(`Connection Gateway session 清理失败: ${formatErrorMessage(cleanupError)}`);
+    });
+    throw error;
+  });
   const decoder = new ContentLengthJsonFrameDecoder(1024 * 1024 * 16);
   const targetsByPluginId = new Map(targets.map((target) => [target.snapshot.pluginId, target]));
   let closed = false;
 
-  const closedPromise = new Promise<void>((resolve, reject) => {
-    socket.once('close', () => {
+  const closedPromise = new Promise<void>((resolve) => {
+    socket.once('close', async () => {
       closed = true;
+      await deleteGatewaySession(session, options).catch((error) => {
+        onLog?.(`Connection Gateway session 清理失败: ${formatErrorMessage(error)}`);
+      });
       resolve();
     });
-    socket.once('error', reject);
+    socket.once('error', (error) => {
+      onLog?.(`Connection Gateway TCP 错误: ${error.message}`);
+    });
   });
 
   socket.on('data', (chunk) => {
@@ -106,6 +188,12 @@ export async function connectDebugGateway({
         version: target.snapshot.version
       }))
     }
+  }).catch(async (error) => {
+    socket.destroy(error instanceof Error ? error : new Error(String(error)));
+    await deleteGatewaySession(session, options).catch((cleanupError) => {
+      onLog?.(`Connection Gateway session 清理失败: ${formatErrorMessage(cleanupError)}`);
+    });
+    throw error;
   });
   onLog?.(`已连接 Connection Gateway session: ${session.id}`);
 
@@ -118,6 +206,26 @@ export async function connectDebugGateway({
     },
     closed: closedPromise
   };
+}
+
+async function deleteGatewaySession(
+  session: ConnectionGatewaySession,
+  options: DebugGatewayClientOptions
+): Promise<void> {
+  const response = await fetch(
+    `${normalizeBaseUrl(options.baseUrl)}/internal/sessions/${encodeURIComponent(session.id)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${options.authToken}`
+      }
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Gateway session delete failed: ${response.status} ${text}`);
+  }
 }
 
 async function handleGatewayEnvelope({
@@ -410,4 +518,14 @@ function requiredRequestId(envelope: ConnectionGatewayEnvelope): string {
   }
 
   return envelope.requestId;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/connection-gateway/src/deps.ts
+++ b/apps/connection-gateway/src/deps.ts
@@ -62,6 +62,13 @@ export function makeConnectionGatewayDeps() {
         if (binding) {
           binding.closed = true;
           boundConnections.delete(connection.id);
+          void service.closeSession(binding.sessionId, 'tcp_connection_closed').catch((error) => {
+            logger.warn('Connection Gateway TCP session close status update failed', {
+              connectionId: connection.id,
+              sessionId: binding.sessionId,
+              error
+            });
+          });
         }
       },
       onEnvelope: async (connection, envelope) => {

--- a/packages/infrastructure/src/connection-gateway/service.test.ts
+++ b/packages/infrastructure/src/connection-gateway/service.test.ts
@@ -88,6 +88,20 @@ function makeEnvelope(sessionId: string, generation: number): ConnectionGatewayE
   };
 }
 
+function makeBindEnvelope(sessionId: string, generation: number): ConnectionGatewayEnvelope {
+  return {
+    protocol: 'connection-gateway.v1',
+    sessionId,
+    generation,
+    requestId: 'bind-a',
+    type: 'event',
+    consumerType: 'plugin-debug',
+    capability: 'gateway.bind',
+    createdAt: now,
+    payload: { kind: 'plugin-debug.bind' }
+  };
+}
+
 describe('ConnectionGatewayService', () => {
   it('creates scoped sessions and publishes opaque envelopes to the mailbox', async () => {
     const { service, token, metrics } = makeService();
@@ -95,6 +109,10 @@ describe('ConnectionGatewayService', () => {
       token: await signDebugToken(token),
       transport: 'tcp',
       now
+    });
+    await service.bindSession({
+      sessionId: session.id,
+      envelope: makeBindEnvelope(session.id, session.generation)
     });
 
     const result = await service.publishRequest({
@@ -106,6 +124,7 @@ describe('ConnectionGatewayService', () => {
       session: expect.objectContaining({
         id: session.id,
         subject: 'user:u1',
+        status: 'connected',
         generation: 0
       }),
       ownerAlive: true,
@@ -125,6 +144,10 @@ describe('ConnectionGatewayService', () => {
       token: signed,
       transport: 'tcp',
       now
+    });
+    await service.bindSession({
+      sessionId: session.id,
+      envelope: makeBindEnvelope(session.id, session.generation)
     });
 
     await expect(
@@ -165,6 +188,10 @@ describe('ConnectionGatewayService', () => {
       token: await signDebugToken(token),
       transport: 'tcp',
       now
+    });
+    await service.bindSession({
+      sessionId: session.id,
+      envelope: makeBindEnvelope(session.id, session.generation)
     });
     const request = makeEnvelope(session.id, session.generation);
     const { responses } = await service.publishRequestAndWait({
@@ -247,12 +274,75 @@ describe('ConnectionGatewayService', () => {
     });
   });
 
+  it('keeps connecting and closed sessions visible but fails requests closed', async () => {
+    const { service, token } = makeService();
+    const session = await service.createSession({
+      token: await signDebugToken(token),
+      transport: 'tcp',
+      now
+    });
+
+    await expect(service.getStatus(session.id)).resolves.toMatchObject({
+      session: expect.objectContaining({
+        status: 'connecting'
+      }),
+      ownerAlive: false
+    });
+    await expect(
+      service.publishRequest({
+        sessionId: session.id,
+        envelope: makeEnvelope(session.id, session.generation)
+      })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.session_owner_expired',
+      data: {
+        status: 'connecting'
+      }
+    });
+
+    await service.bindSession({
+      sessionId: session.id,
+      envelope: makeBindEnvelope(session.id, session.generation)
+    });
+    await service.closeSession(session.id, 'unit_test_closed');
+
+    await expect(service.getStatus(session.id)).resolves.toMatchObject({
+      session: expect.objectContaining({
+        status: 'closed'
+      }),
+      ownerAlive: false,
+      logs: expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Gateway session closed',
+          data: {
+            reason: 'unit_test_closed'
+          }
+        })
+      ])
+    });
+    await expect(
+      service.publishRequest({
+        sessionId: session.id,
+        envelope: makeEnvelope(session.id, session.generation)
+      })
+    ).rejects.toMatchObject({
+      code: 'connection_gateway.session_owner_expired',
+      data: {
+        status: 'closed'
+      }
+    });
+  });
+
   it('denies response envelopes without the session capability', async () => {
     const { service, token } = makeService();
     const session = await service.createSession({
       token: await signDebugToken(token),
       transport: 'tcp',
       now
+    });
+    await service.bindSession({
+      sessionId: session.id,
+      envelope: makeBindEnvelope(session.id, session.generation)
     });
 
     await expect(

--- a/packages/infrastructure/src/connection-gateway/service.ts
+++ b/packages/infrastructure/src/connection-gateway/service.ts
@@ -69,6 +69,7 @@ export class ConnectionGatewayService {
       transport: claims.transport,
       capabilities: claims.capabilities,
       ownerNodeId: this.deps.options.nodeId,
+      status: 'connecting',
       expiresAt,
       metadata: input.metadata,
       now
@@ -76,7 +77,7 @@ export class ConnectionGatewayService {
 
     await this.deps.mailbox.expire(session.id, this.deps.options.sessionTtlMs);
     this.deps.metrics.recordSessionOpened();
-    this.pushLog(session.id, 'info', 'Gateway session connected', {
+    this.pushLog(session.id, 'info', 'Gateway session created', {
       consumerType: session.consumerType,
       subject: session.subject,
       transport: session.transport,
@@ -93,7 +94,9 @@ export class ConnectionGatewayService {
 
     return {
       session,
-      ownerAlive: Boolean(session && session.expiresAt > Date.now()),
+      ownerAlive: Boolean(
+        session && session.status === 'connected' && session.expiresAt > Date.now()
+      ),
       mailboxLag,
       logs: this.logs.get(sessionId) ?? []
     };
@@ -101,7 +104,12 @@ export class ConnectionGatewayService {
 
   async getLatestStatusBySource(source: string): Promise<ConnectionGatewaySessionStatusView> {
     const sessions = await this.deps.sessionRegistry.listBySource(source);
-    const session = sessions.sort((a, b) => b.lastSeenAt - a.lastSeenAt)[0] ?? null;
+    const session =
+      sessions
+        .filter((item) => item.status === 'connected')
+        .sort((a, b) => b.lastSeenAt - a.lastSeenAt)[0] ??
+      sessions.sort((a, b) => b.lastSeenAt - a.lastSeenAt)[0] ??
+      null;
 
     if (!session) {
       return {
@@ -209,7 +217,8 @@ export class ConnectionGatewayService {
   }): Promise<ConnectionGatewaySession> {
     const envelope = ConnectionGatewayEnvelopeSchema.parse(input.envelope);
     const session = await this.assertEnvelopeSession(input.sessionId, envelope, {
-      requireCapability: false
+      requireCapability: false,
+      requireConnected: false
     });
 
     if (envelope.type !== 'event' || envelope.capability !== 'gateway.bind') {
@@ -218,6 +227,11 @@ export class ConnectionGatewayService {
       });
     }
 
+    await this.deps.sessionRegistry.updateStatus({
+      sessionId: session.id,
+      ownerNodeId: this.deps.options.nodeId,
+      status: 'connected'
+    });
     await this.renewOwnerLease(session.id);
     this.pushLog(session.id, 'info', 'Gateway TCP session bound', {
       consumerType: session.consumerType,
@@ -227,6 +241,26 @@ export class ConnectionGatewayService {
     });
 
     return session;
+  }
+
+  async closeSession(sessionId: string, reason?: string): Promise<boolean> {
+    const session = await this.deps.sessionRegistry.get(sessionId);
+    const closed = await this.deps.sessionRegistry.updateStatus({
+      sessionId,
+      ownerNodeId: this.deps.options.nodeId,
+      status: 'closed'
+    });
+
+    if (closed) {
+      if (session?.status !== 'closed') {
+        this.deps.metrics.recordSessionClosed();
+      }
+      this.pushLog(sessionId, 'warn', 'Gateway session closed', {
+        ...(reason ? { reason } : {})
+      });
+    }
+
+    return closed;
   }
 
   async readSessionRequests(input: {
@@ -251,7 +285,9 @@ export class ConnectionGatewayService {
     const session = await this.deps.sessionRegistry.get(sessionId);
     await this.deps.sessionRegistry.remove(sessionId);
     if (session) {
-      this.deps.metrics.recordSessionClosed();
+      if (session.status !== 'closed') {
+        this.deps.metrics.recordSessionClosed();
+      }
       this.pushLog(sessionId, 'info', 'Gateway session deleted');
     }
   }
@@ -274,7 +310,7 @@ export class ConnectionGatewayService {
   private async assertEnvelopeSession(
     sessionId: string,
     envelope: ConnectionGatewayEnvelope,
-    options: { requireCapability?: boolean } = {}
+    options: { requireCapability?: boolean; requireConnected?: boolean } = {}
   ): Promise<ConnectionGatewaySession> {
     const session = await this.deps.sessionRegistry.get(sessionId);
     if (!session) {
@@ -284,6 +320,15 @@ export class ConnectionGatewayService {
     if (session.expiresAt <= Date.now()) {
       this.deps.metrics.recordOwnerLeaseExpiry();
       throw createError(ErrorCode.connectionGatewaySessionOwnerExpired);
+    }
+
+    if (options.requireConnected !== false && session.status !== 'connected') {
+      throw createError(ErrorCode.connectionGatewaySessionOwnerExpired, {
+        message: `Gateway session is ${session.status}`,
+        data: {
+          status: session.status
+        }
+      });
     }
 
     if (envelope.sessionId !== session.id) {

--- a/packages/infrastructure/src/plugin/debug-plugin.repo.test.ts
+++ b/packages/infrastructure/src/plugin/debug-plugin.repo.test.ts
@@ -59,6 +59,27 @@ describe('DebugPluginRepoOverlay', () => {
       }
     });
   });
+
+  it('does not expose debug metadata from a disconnected session', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(makeGatewayStatus({ status: 'closed', ownerAlive: false }))
+    );
+    const repo = createRepo();
+
+    const [, err] = await repo.getPluginByUserPluginId({
+      pluginId: 'getTime',
+      source: 'debug:user:u1'
+    });
+
+    expect(err).toMatchObject({
+      code: 'connection_gateway.session_not_found',
+      data: {
+        source: 'debug:user:u1',
+        status: 'closed',
+        ownerAlive: false
+      }
+    });
+  });
 });
 
 function createRepo(): DebugPluginRepoOverlay {
@@ -98,11 +119,15 @@ function jsonResponse(payload: unknown): Response {
   });
 }
 
-function makeGatewayStatus() {
+function makeGatewayStatus({
+  status = 'connected',
+  ownerAlive = true
+}: { status?: string; ownerAlive?: boolean } = {}) {
   return {
     data: {
       session: {
         id: 'session-a',
+        status,
         sessionScope: {
           source: 'debug:user:u1'
         },
@@ -114,7 +139,8 @@ function makeGatewayStatus() {
             ]
           }
         }
-      }
+      },
+      ownerAlive
     }
   };
 }

--- a/packages/infrastructure/src/plugin/debug-plugin.repo.ts
+++ b/packages/infrastructure/src/plugin/debug-plugin.repo.ts
@@ -31,6 +31,7 @@ type GatewayStatusResponse = {
   data: {
     session: {
       id: string;
+      status?: string;
       sessionScope: {
         source?: string;
       };
@@ -38,6 +39,7 @@ type GatewayStatusResponse = {
         pluginDebug?: DebugPluginMetadata | DebugPluginMetadataBundle;
       };
     } | null;
+    ownerAlive?: boolean;
   };
 };
 
@@ -309,6 +311,23 @@ export class DebugPluginRepoOverlay implements PluginRepoPort {
       }
 
       const payload = JSON.parse(text) as GatewayStatusResponse;
+      if (!payload.data.session || payload.data.session.status !== 'connected' || payload.data.ownerAlive === false) {
+        return failureResult(
+          createError(ErrorCode.connectionGatewaySessionNotFound, {
+            message: `Debug plugin session is not connected: ${source}`,
+            reason: {
+              en: `Debug plugin session is not connected: ${source}`,
+              'zh-CN': `调试插件会话未连接: ${source}`
+            },
+            data: {
+              source,
+              status: payload.data.session?.status,
+              ownerAlive: payload.data.ownerAlive
+            }
+          })
+        );
+      }
+
       return successResult(payload.data.session?.metadata?.pluginDebug);
     } catch (error) {
       return failureResult(

--- a/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.test.ts
+++ b/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.test.ts
@@ -19,9 +19,11 @@ describe('ConnectionGatewayDebugRuntimeManager', () => {
             session: {
               id: 'session-a',
               consumerType: 'plugin-debug',
-              generation: 0
+              generation: 0,
+              status: 'connected'
             }
-          }
+          },
+          ownerAlive: true
         })
       )
       .mockResolvedValueOnce(

--- a/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.ts
+++ b/packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.ts
@@ -137,9 +137,18 @@ export class ConnectionGatewayDebugRuntimeManager
     );
     const session = status.data.session;
 
-    if (!session || session.consumerType !== CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE) {
+    if (
+      !session ||
+      session.consumerType !== CONNECTION_GATEWAY_PLUGIN_DEBUG_CONSUMER_TYPE ||
+      session.status !== 'connected' ||
+      status.data.ownerAlive === false
+    ) {
       throw createError(ErrorCode.connectionGatewaySessionNotFound, {
-        data: { source }
+        data: {
+          source,
+          status: session?.status,
+          ownerAlive: status.data.ownerAlive
+        }
       });
     }
 
@@ -232,11 +241,13 @@ type GatewayDebugSession = {
   id: string;
   consumerType: string;
   generation: number;
+  status: string;
 };
 
 type GatewayStatusResponse = {
   data: {
     session: GatewayDebugSession | null;
+    ownerAlive?: boolean;
   };
 };
 


### PR DESCRIPTION
## Summary
- Add explicit gateway debug session lifecycle states: `connecting`, `connected`, and `closed`.
- Fail closed for disconnected debug sessions so debug metadata and invocation are only available for connected sessions.
- Mark TCP sessions closed when the socket disconnects and preserve status/logs for diagnostics.
- Add CLI gateway reconnect support, session cleanup on normal close, and cleanup for failed TCP/bind attempts.
- Document remote debug gateway usage and single-channel multi-plugin behavior.

## Test plan
- [x] `pnpm exec tsc --noEmit --pretty false --incremental false`
- [x] `pnpm --dir apps/cli exec vitest run src/commands/debug.spec.ts src/debug/gateway.spec.ts --config vitest.config.ts --pool=forks`
- [x] `pnpm exec vitest run packages/infrastructure/src/connection-gateway/service.test.ts packages/infrastructure/src/plugin/debug-plugin.repo.test.ts packages/infrastructure/src/plugin/plugin-runtime/drivers/connection-gateway/debug-runtime.driver.test.ts --pool=forks`
- [x] targeted `pnpm exec eslint ...`
- [x] `pnpm build:connection-gateway`
- [x] `pnpm --dir apps/cli build`
- [x] `git diff --check`

## Notes
- Vitest still prints existing `.env.test` / `.env.test.local` warnings; tests pass.
- connection-gateway build still prints the existing protobufjs direct-eval bundling warning; build passes.