### PR TITLE
[codex] add Kimi K2.7 Code preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/DeepSeek/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/DeepSeek/index.ts
@@ -14,10 +14,7 @@ const models: ProviderConfigType = {
       vision: false,
       reasoning: true,
       reasoningEffort: true,
-      toolChoice: true,
-      defaultConfig: {
-        thinking: { type: 'enabled' }
-      }
+      toolChoice: true
     },
     {
       type: ModelTypeEnum.llm,
@@ -30,10 +27,7 @@ const models: ProviderConfigType = {
       vision: false,
       reasoning: true,
       reasoningEffort: true,
-      toolChoice: true,
-      defaultConfig: {
-        thinking: { type: 'enabled' }
-      }
+      toolChoice: true
     },
     {
       type: ModelTypeEnum.llm,

--- a/packages/infrastructure/src/static-data/models/provider/Moonshot/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Moonshot/index.ts
@@ -5,6 +5,20 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'kimi-k2.7-code',
+      maxContext: 262144,
+      maxTokens: 32768,
+      quoteMaxToken: 256000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_object'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      showTopP: false
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'kimi-k2.6',
       maxContext: 262144,
       maxTokens: 32000,
@@ -15,12 +29,7 @@ const models: ProviderConfigType = {
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true,
-      showTopP: false,
-      defaultConfig: {
-        thinking: {
-          type: 'enabled'
-        }
-      }
+      showTopP: false
     },
     {
       type: ModelTypeEnum.llm,
@@ -34,12 +43,7 @@ const models: ProviderConfigType = {
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true,
-      showTopP: false,
-      defaultConfig: {
-        thinking: {
-          type: 'enabled'
-        }
-      }
+      showTopP: false
     },
     {
       type: ModelTypeEnum.llm,


### PR DESCRIPTION
## Summary
- add Moonshot `kimi-k2.7-code` as the newest Kimi preset
- keep K2 capability flags for multimodal input, reasoning, tool calls, and JSON mode
- remove static `defaultConfig.thinking = { type: 'enabled' }` from model presets now that thinking configuration is handled by the system
- set `kimi-k2.7-code` `maxTokens` to the documented 32k / 32768 default output limit

## Evidence
- Official Kimi model list (`https://platform.kimi.ai/docs/models`) lists `kimi-k2.7-code` as a public multimodal model with 256k context.
- Official Kimi K2.7 Code pricing/quickstart pages document 262,144-token context, 32768 default `max_tokens`, thinking mode support, ToolCalls, JSON Mode, and image/video input support.

## Validation
- `rg -n "thinking:\\s*\\{|type:\\s*'enabled'|type:\\s*\\\"enabled\\\"" packages/infrastructure/src/static-data/models/provider || true`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Moonshot,DeepSeek`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs check-sources --provider Moonshot,DeepSeek`
- `git diff --check`
- `./node_modules/.bin/eslint packages/infrastructure/src/static-data/models/provider/Moonshot/index.ts packages/infrastructure/src/static-data/models/provider/DeepSeek/index.ts`
- `./node_modules/.bin/tsx -e "..."` import/preset assertion
- `corepack pnpm typecheck`
- `corepack pnpm test` (passes; logs existing missing `.env.test` / `.env.test.local` warnings and Vitest coverage package version warning)
