### PR TITLE
[codex] Remove deprecated Mistral presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
@@ -41,31 +41,6 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'magistral-medium-2509',
-      maxContext: 128000,
-      maxTokens: 32000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1.2,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true,
-      responseFormatList: ['text']
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'mistral-medium-2508',
-      maxContext: 128000,
-      maxTokens: 8000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1.2,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'ministral-14b-2512',
       maxContext: 131000,
       maxTokens: 8000,


### PR DESCRIPTION
## Summary

- Remove the deprecated MistralAI `magistral-medium-2509` preset.
- Remove the deprecated MistralAI `mistral-medium-2508` preset.

## Evidence

Mistral's official Models Overview lists both model IDs in the Legacy / Deprecated section with a 2026-05-22 deprecation date and points users to `mistral-medium-3-5` as the replacement.

## Validation

- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/model-provider-plan-20260614.json --dry-run`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/model-provider-plan-20260614.json --write`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider MistralAI`
- `git diff --check`
- `pnpm typecheck`
- `pnpm test`

Notes: the full test run passes, while the repo emits existing warnings for missing optional `.env.test` / `.env.test.local` files and mixed `vitest` / `@vitest/coverage-v8` versions.
