### PR TITLE
feat: add Groq Llama 4 presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
@@ -70,6 +70,30 @@ const models: ProviderConfigType = {
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'meta-llama/llama-4-scout-17b-16e-instruct',
+      maxContext: 131072,
+      maxTokens: 8000,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'meta-llama/llama-4-maverick-17b-128e-instruct',
+      maxContext: 131072,
+      maxTokens: 8000,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
     }
   ]
 };


### PR DESCRIPTION
## Summary

- Add Groq presets for `meta-llama/llama-4-scout-17b-16e-instruct` and `meta-llama/llama-4-maverick-17b-128e-instruct`.
- Keep the presets aligned with the existing Groq Llama chat-model shape while setting the documented 128K context window and vision support.

## Evidence

- Checked Groq official model docs on 2026-06-15: https://console.groq.com/docs/models
- Groq docs expose both Llama 4 model IDs in the Chat API model enum and provide dedicated model cards describing text/image multimodal support and a 128K token context window.

## Validation

- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Groq` passes and reports 9 Groq models.
- `git diff --check` passes.
- `bun -e "import('./packages/infrastructure/src/static-data/models/provider/Groq/index.ts').then(...)"` imports the provider and confirms both Llama 4 IDs are present.
- `bun run test` currently fails outside this change in `sdk/factory/src/tool-factory.test.ts` because installed Zod v3 lacks `.meta()`.
- `bun tsc --noEmit` currently fails with the same SDK/Zod API mismatch (`GlobalMeta`, `.meta()`, `toJSONSchema`).
