### PR TITLE
[codex] refresh Moonshot model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Moonshot/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Moonshot/index.ts
@@ -19,6 +19,20 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'kimi-k2.7-code-highspeed',
+      maxContext: 262144,
+      maxTokens: 32768,
+      quoteMaxToken: 256000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_object'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      showTopP: false
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'kimi-k2.6',
       maxContext: 262144,
       maxTokens: 32000,


### PR DESCRIPTION
## Summary
- add the Moonshot/Kimi `kimi-k2.7-code-highspeed` model preset
- mirror the existing `kimi-k2.7-code` capability fields because the official catalog describes it as the high-speed Kimi K2.7 Code variant

## Evidence
- Official Kimi model catalog checked on 2026-06-16: https://platform.kimi.ai/docs/models.md
- The catalog lists both `kimi-k2.7-code` and `kimi-k2.7-code-highspeed` under the current multi-modal models.

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Moonshot`
- `pnpm exec eslint packages/infrastructure/src/static-data/models/provider/Moonshot/index.ts`
- `git diff --check`

## Notes
- `pnpm typecheck` currently fails in SDK factory code due to the local Zod v3/v4 API mismatch (`GlobalMeta`, `.meta`, and `toJSONSchema` are unavailable from the resolved zod/v3 package).
- `bun run test` reaches the same unrelated Zod metadata issue in `sdk/factory/src/tool-factory.test.ts` (`z.string().meta is not a function`).
