### PR TITLE
[codex] add GLM-5.2 preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts
@@ -5,6 +5,19 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'glm-5.2',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 900000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object'],
+      vision: false,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'glm-5.1',
       maxContext: 200000,
       maxTokens: 128000,


### PR DESCRIPTION
## Summary

- Add a ChatGLM preset for `glm-5.2`.
- Set the preset from official Zhipu docs: 1M context, 128K max output, text-only input, reasoning effort, and tool calling support.

## Evidence

- Checked Zhipu official model docs on 2026-06-17: https://docs.bigmodel.cn/cn/guide/models/text/glm-5.2
- The official model overview lists GLM-5.2 as the latest flagship text model with 1M context and 128K max output: https://docs.bigmodel.cn/cn/guide/start/model-overview
- The GLM-5.2 page documents `model: "glm-5.2"`, `max_tokens: 65536` examples, `reasoning_effort`, thinking mode, and Function Call support.

## Validation

- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider ChatGLM` passes and reports 26 ChatGLM models.
- `git diff --check` passes.
- `bun -e "import('./packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts').then(...)"` imports the provider and confirms `glm-5.2` is present with the expected limits.
- `bun run test` currently fails outside this change in `sdk/factory/src/tool-factory.test.ts` because installed Zod v3 lacks `.meta()`.
- `bun tsc --noEmit` currently fails with the same SDK/Zod API mismatch (`GlobalMeta`, `.meta()`, `toJSONSchema`).
