### PR TITLE
[codex] add ERNIE 5.1 preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Ernie/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Ernie/index.ts
@@ -5,6 +5,18 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'ernie-5.1',
+      maxContext: 128000,
+      maxTokens: 65536,
+      quoteMaxToken: 119000,
+      maxTemperature: 1,
+      vision: false,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: false
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'ERNIE-4.0-8K',
       maxContext: 8000,
       maxTokens: 2048,


### PR DESCRIPTION
## Summary
- Add the Baidu Qianfan `ernie-5.1` preset to the Ernie provider registry.
- Use the official Qianfan model list values: 128k context, 119k max input quote budget, and 65,536 max output tokens.

## Evidence
- Official model list: https://cloud.baidu.com/doc/qianfan/s/rmh4stp0j
- Official pricing page cross-check: https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya
- Checked on 2026-06-18; both pages were updated by Baidu on 2026-06-17 and list ERNIE 5.1 / ERNIE-5.1.

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Ernie`
- `bun -e "const mod = await import('./packages/infrastructure/src/static-data/models/provider/Ernie/index.ts'); const item = mod.default.list.find((m) => m.model === 'ernie-5.1'); if (!item) throw new Error('missing ernie-5.1'); if (item.maxContext !== 128000 || item.maxTokens !== 65536 || item.quoteMaxToken !== 119000) throw new Error('bad ernie-5.1 fields'); console.log(JSON.stringify(item));"`
- `pnpm exec eslint packages/infrastructure/src/static-data/models/provider/Ernie/index.ts`
- `git diff --check`

## Known Existing Failures
- `bun run test` still fails in `sdk/factory/src/tool-factory.test.ts` because the resolved SDK Zod package lacks `z.string().meta`.
- `bun tsc --noEmit` still fails on the same SDK Zod v3/v4 mismatch (`GlobalMeta`, `.meta`, and `toJSONSchema` unavailable).
