### PR TITLE
[codex] Add Grok and Mistral model aliases

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
@@ -17,6 +17,30 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'grok-4.3-latest',
+      maxContext: 1000000,
+      maxTokens: 8000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'grok-latest',
+      maxContext: 1000000,
+      maxTokens: 8000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'grok-4.20-multi-agent-0309',
       maxContext: 1000000,
       maxTokens: 8000,

--- a/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
@@ -41,6 +41,18 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'mistral-medium-latest',
+      maxContext: 256000,
+      maxTokens: 32000,
+      quoteMaxToken: 240000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'magistral-medium-2509',
       maxContext: 128000,
       maxTokens: 32000,


### PR DESCRIPTION
## Summary

- add xAI Grok chat aliases `grok-4.3-latest` and `grok-latest`
- add Mistral API alias `mistral-medium-latest`

## Evidence

- xAI Grok 4.3 docs list `grok-4.3`, `grok-4.3-latest`, and `grok-latest` for the Grok 4.3 chat model, with 1M prompt length in the embedded model data.
- Mistral function-calling support docs list Mistral Medium 3.5 with API model ID `mistral-medium-latest`.
- No removals were made because no audited official source marked existing local presets as retired or unsupported.

## Validation

- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Grok,MistralAI`
- `bunx eslint packages/infrastructure/src/static-data/models/provider/Grok/index.ts packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts`
- `bunx tsx -e "import Grok from './packages/infrastructure/src/static-data/models/provider/Grok/index.ts'; import MistralAI from './packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts'; console.log(Grok.list.map(m => m.model).join('\\n')); console.log('---'); console.log(MistralAI.list.map(m => m.model).join('\\n'));"`
- `git diff --check`

Full-suite status:

- `bun tsc --noEmit` still fails in existing `sdk/factory` zod v3/v4 mismatch: installed zod v3 lacks `GlobalMeta`, `.meta`, and `toJSONSchema`.
- `bun run test` still has 25 passing files, 167 passing tests, and 1 failing `sdk/factory` metadata test: `z.string().meta is not a function`.
