### PR TITLE
chore: update Groq model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
@@ -17,6 +17,30 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'groq/compound-mini',
+      maxContext: 131072,
+      maxTokens: 8192,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: false,
+      reasoning: true,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'groq/compound',
+      maxContext: 131072,
+      maxTokens: 8192,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: false,
+      reasoning: true,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'openai/gpt-oss-20b',
       maxContext: 131072,
       maxTokens: 65536,
@@ -73,7 +97,31 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'moonshotai/kimi-k2-instruct',
+      maxContext: 131072,
+      maxTokens: 8192,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: false,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'meta-llama/llama-4-scout-17b-16e-instruct',
+      maxContext: 131072,
+      maxTokens: 8192,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'meta-llama/llama-4-maverick-17b-128e-instruct',
       maxContext: 131072,
       maxTokens: 8192,
       quoteMaxToken: 120000,


### PR DESCRIPTION
## Summary
- add Groq `groq/compound` and `groq/compound-mini` production system presets
- add Groq-hosted `meta-llama/llama-4-maverick-17b-128e-instruct` and `moonshotai/kimi-k2-instruct`
- audited high-change model providers against official sources; no removals were made without explicit retirement evidence

## Sources checked
- OpenAI: https://platform.openai.com/docs/models
- Anthropic: https://docs.anthropic.com/en/docs/about-claude/models
- Gemini: https://ai.google.dev/gemini-api/docs/models
- xAI: https://docs.x.ai/docs/models
- Groq: https://console.groq.com/docs/models
- Mistral: https://docs.mistral.ai/getting-started/models/models_overview/
- Qwen: https://help.aliyun.com/zh/model-studio/getting-started/models
- DeepSeek: https://api-docs.deepseek.com/quick_start/pricing
- Zhipu: https://docs.bigmodel.cn/cn/guide/models
- MiniMax: https://platform.minimaxi.com/document/Models
- Moonshot/Kimi: https://platform.kimi.ai/docs/models
- StepFun: https://platform.stepfun.com/docs/zh/guides/models/overview

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Groq`
- `git diff --check`
- `pnpm exec tsx -e "import('./packages/infrastructure/src/static-data/models/provider/Groq/index.ts')..."`

## Known unrelated validation failures
- `pnpm typecheck` currently fails in `sdk/factory` on Zod v3/v4 API/type mismatches such as missing `GlobalMeta`, `meta`, and `toJSONSchema`.
- `pnpm test` currently has 1 failing SDK factory test: `default.string(...).meta is not a function`; test setup also warns that `.env.test` is missing.
