### PR TITLE
feat(model): add Grok 4.20 preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
@@ -41,6 +41,18 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'grok-4.20',
+      maxContext: 1000000,
+      maxTokens: 8000,
+      quoteMaxToken: 1000000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'grok-4.20-0309-non-reasoning',
       maxContext: 1000000,
       maxTokens: 8000,


### PR DESCRIPTION
## Summary
- add the public xAI `grok-4.20` main-family preset to the Grok static provider
- clone the existing Grok 4.20 reasoning-family capability fields already maintained locally
- keep snapshot, `*-latest`, beta, multi-agent, image, video, and voice variants out of this narrow static preset update

## Evidence
- xAI models docs: https://docs.x.ai/docs/models
- xAI Grok 4.20 docs/page data: https://docs.x.ai/docs/models/grok-4.20
- checked on 2026-06-27
- official docs list `grok-4.20` as a public model/alias, while current `main` only had dated or variant Grok 4.20 IDs
- the Grok 4.20 page data reports a 1,000,000 max prompt length, matching the existing local Grok 4.20 family presets

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/plugin-model-update-plan.json --dry-run` passed
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Grok` passed: Grok now has 10 LLM presets
- `pnpm exec tsx -e "import models from './packages/infrastructure/src/static-data/models/provider/Grok/index.ts'; ..."` passed and found `grok-4.20`
- `pnpm exec eslint packages/infrastructure/src/static-data/models/provider/Grok/index.ts` passed
- `git diff --check` passed
- `bun tsc --noEmit` still fails on the existing `sdk/factory` Zod v3/v4 API mismatch (`GlobalMeta`, `.meta`, `toJSONSchema` missing)
- `bun run test` still has 25 passing files, 169 passing tests, and 1 existing failing SDK factory test: `default.string(...).meta is not a function`; setup also warns `.env.test` is missing
