### PR TITLE
feat(model): remove deprecated Mistral presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
@@ -41,31 +41,6 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'magistral-medium-2509',
-      maxContext: 128000,
-      maxTokens: 32000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1.2,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true,
-      responseFormatList: ['text']
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'mistral-medium-2508',
-      maxContext: 128000,
-      maxTokens: 8000,
-      quoteMaxToken: 120000,
-      maxTemperature: 1.2,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'ministral-14b-2512',
       maxContext: 131000,
       maxTokens: 8000,


### PR DESCRIPTION
## Summary

- Remove MistralAI presets for `mistral-medium-2508` and `magistral-medium-2509`.
- Keep the existing `mistral-medium-3-5` preset as the documented replacement model.

## Evidence

- Source checked: https://docs.mistral.ai/models/overview on 2026-06-28.
- Mistral's official models overview lists `mistral-medium-2508` with deprecation date 2026-05-22 and retirement date 2026-08-31.
- The same page lists `magistral-medium-2509` with deprecation date 2026-05-22 and retirement date 2026-07-31.
- The page presents Mistral Medium 3.5 as a featured/frontier model; `mistral-medium-3-5` already exists locally.

## Validation

- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/plugin-mistral-plan.json --dry-run`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider MistralAI`
- `pnpm exec tsx -e "import models from './packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts'; ..."`
- `pnpm exec eslint packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts`
- `git diff --check`

Full-repo checks were also run and still fail on unrelated latest-main issues:

- `bun tsc --noEmit`: missing dependency/type resolution for `ink`, `react`, `@hono/node-server`, `hono/cors`, plus existing SDK factory Zod v3/v4 API mismatches (`GlobalMeta`, `.meta`, `toJSONSchema`).
- `bun run test`: 37 files passed, 2 failed. Failures are `apps/connection-gateway/src/routes.test.ts` missing `hono/cors` and `sdk/factory/src/tool-factory.test.ts` with `default.string(...).meta is not a function`; setup also warns `.env.test` is missing.
