### PR TITLE
chore: refresh Groq model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
@@ -40,6 +40,18 @@ const models: ProviderConfigType = {
       toolChoice: true
     },
     {
+      type: ModelTypeEnum.llm,
+      model: 'qwen/qwen3.6-27b',
+      maxContext: 131072,
+      maxTokens: 32768,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
       type: ModelTypeEnum.stt,
       model: 'whisper-large-v3'
     },
@@ -73,7 +85,31 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'moonshotai/kimi-k2-instruct',
+      maxContext: 131072,
+      maxTokens: 8192,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: false,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'meta-llama/llama-4-scout-17b-16e-instruct',
+      maxContext: 131072,
+      maxTokens: 8192,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'meta-llama/llama-4-maverick-17b-128e-instruct',
       maxContext: 131072,
       maxTokens: 8192,
       quoteMaxToken: 120000,


### PR DESCRIPTION
## Summary\n- add Groq presets for qwen/qwen3.6-27b, moonshotai/kimi-k2-instruct, and meta-llama/llama-4-maverick-17b-128e-instruct\n- keep additions scoped to active Groq chat models documented on the official Groq model pages\n\n## Validation\n- pnpm exec tsx -e "import groq from './packages/infrastructure/src/static-data/models/provider/Groq/index.ts'; import { ProviderConfigSchema } from './packages/infrastructure/src/static-data/models/type.ts'; const result = ProviderConfigSchema.safeParse(groq); if (!result.success) { console.error(result.error.format()); process.exit(1); } console.log(JSON.stringify({ provider: result.data.provider, models: result.data.list.length, llm: result.data.list.filter((item) => item.type === 'llm').length }, null, 2));"\n- pnpm exec eslint packages/infrastructure/src/static-data/models/provider/Groq/index.ts\n- git diff --check\n\n## Notes\n- bun run test currently fails outside this change in sdk/factory/src/tool-factory.test.ts because z.string().meta is unavailable with the installed Zod v3 path.\n- bun tsc --noEmit currently fails outside this change on the same SDK Zod v3/v4 mismatch (missing GlobalMeta/meta/toJSONSchema).