### PR TITLE
chore: remove suspended Claude Fable preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
@@ -5,19 +5,6 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
-      model: 'claude-fable-5',
-      maxContext: 1000000,
-      maxTokens: 128000,
-      quoteMaxToken: 200000,
-      maxTemperature: null,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true,
-      showTopP: false
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'claude-opus-4-8',
       maxContext: 1000000,
       maxTokens: 128000,


### PR DESCRIPTION
## Summary
- Remove the Claude provider preset for `claude-fable-5`.
- Keep the rest of the Claude provider unchanged because Anthropic states other models are unaffected.

## Evidence
- Source checked: https://www.anthropic.com/news/fable-mythos-access on 2026-06-30.
- Anthropic's June 12, 2026 statement says access to Fable 5 and Mythos 5 must be disabled for all customers.
- `claude-mythos-5` is not present locally, so only `claude-fable-5` needed removal.

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/plugin-claude-plan.json --dry-run`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/plugin-claude-plan.json --write`
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Claude`
- `pnpm exec tsx -e "import claude from './packages/infrastructure/src/static-data/models/provider/Claude/index.ts'; import { ProviderConfigSchema } from './packages/infrastructure/src/static-data/models/type.ts'; const result = ProviderConfigSchema.safeParse(claude); if (!result.success) { console.error(result.error.format()); process.exit(1); } console.log(JSON.stringify({ provider: result.data.provider, models: result.data.list.length, ids: result.data.list.map((item) => item.model) }, null, 2));"`
- `pnpm exec eslint packages/infrastructure/src/static-data/models/provider/Claude/index.ts`
- `git diff --check`

## Related open provider PRs
- #489 removes deprecated Mistral presets.
- #490 refreshes Groq presets. This PR is intentionally scoped to Claude to avoid duplicating those queued changes.