### PR TITLE
chore: add latest Claude model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
@@ -5,6 +5,19 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'claude-fable-5',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 200000,
+      maxTemperature: null,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      showTopP: false
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'claude-opus-4-8',
       maxContext: 1000000,
       maxTokens: 128000,
@@ -15,6 +28,18 @@ const models: ProviderConfigType = {
       reasoningEffort: true,
       toolChoice: true,
       showTopP: false
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'claude-sonnet-5',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 200000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
     },
     {
       type: ModelTypeEnum.llm,


### PR DESCRIPTION
## Summary
- Add Claude Fable 5 and Claude Sonnet 5 to the Claude provider presets.
- Keep the existing Claude capability field style and order the new GA IDs ahead of older family versions.

## Sources checked
- Anthropic models page: https://docs.anthropic.com/en/docs/about-claude/models
- OpenAI models page: https://platform.openai.com/docs/models
- Gemini models page: https://ai.google.dev/gemini-api/docs/models
- xAI models page: https://docs.x.ai/docs/models
- Mistral models overview: https://docs.mistral.ai/getting-started/models/models_overview/

## Validation
- pnpm install --frozen-lockfile
- node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory
- bun run test: 39 files / 244 tests passed; existing warnings about missing .env.test files and mixed Vitest versions.
- bun tsc --noEmit: fails in sdk/factory/src/tool-factory.test.ts:285 with an existing PluginChannelStreamSource/StreamData type mismatch unrelated to this provider change.