### PR TITLE
fix(plugin): restore disabled etag installs as active replacement

### DIFF
--- a/packages/infrastructure/src/plugin/plugin.repo.test.ts
+++ b/packages/infrastructure/src/plugin/plugin.repo.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { type PluginType } from '@domain/entities/plugin.entity';
 import { PluginStatusEnum } from '@domain/entities/plugin-base.entity';
+import type { FileObject } from '@domain/value-objects/file/file-object.vo';
 import { type PkgContentFileObjects } from '@domain/value-objects/file/pkg-file.vo';
 import { successResult } from '@domain/value-objects/result.vo';
 
@@ -36,6 +37,26 @@ const pluginRecord = () => {
     }
   };
 };
+
+const fileObject = (fileKey: string, fileName = `${fileKey}.js`) =>
+  ({
+    metaData: {
+      fileKey,
+      fileName,
+      contentType: 'application/javascript',
+      size: 3,
+      etag: `${fileKey}-etag`,
+      createTime: new Date('2026-01-01T00:00:00Z')
+    },
+    get fileStream() {
+      return Promise.resolve(successResult(Readable.from(['pkg'])));
+    }
+  }) as FileObject;
+
+const files = () =>
+  ({
+    index: fileObject('index', 'index.js')
+  }) as PkgContentFileObjects;
 
 describe('PluginRepo.createPlugin', () => {
   it('serializes JSON Schema fields before storing plugin records', () => {
@@ -223,6 +244,145 @@ describe('PluginRepo.createPlugin', () => {
     );
     expect(privateSave).not.toHaveBeenCalled();
     expect(publicSave).not.toHaveBeenCalled();
+  });
+
+  it('restores a disabled plugin with the same version and etag to active during direct installation', async () => {
+    (PluginRepo as any)._instance = undefined;
+
+    const updateOne = vi.fn().mockResolvedValue({ modifiedCount: 1 });
+    const pluginModel = {
+      findOne: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue({
+          _id: 'existing-plugin',
+          status: PluginStatusEnum.disabled
+        })
+      }),
+      find: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([
+          {
+            pluginId: 'plugin-a',
+            version: '1.0.0',
+            etag: 'old-etag'
+          }
+        ])
+      }),
+      updateMany: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
+      updateOne
+    };
+    const installationModel = {
+      deleteMany: vi.fn().mockResolvedValue({ deletedCount: 1 }),
+      updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1 })
+    };
+    const privateSave = vi.fn().mockResolvedValue(successResult(fileObject('stored-index')));
+    const publicSave = vi.fn();
+    const repo = PluginRepo.getInstance({
+      mongoClient: {
+        getModel: vi.fn((modelName: string) =>
+          modelName === 'pluginInstallation' ? installationModel : pluginModel
+        )
+      },
+      privateRemoteFileStorageRepo: {
+        save: privateSave
+      },
+      publicRemoteFileStorageRepo: {
+        save: publicSave
+      }
+    } as unknown as PluginRepoDeps);
+
+    const [, err] = await repo.createPlugin({
+      plugin: plugin(),
+      files: files(),
+      pending: false
+    });
+
+    expect(err).toBeNull();
+    expect(updateOne).toHaveBeenCalledWith(
+      {
+        pluginId: 'plugin-a',
+        version: '1.0.0',
+        etag: 'etag-a'
+      },
+      {
+        $set: expect.objectContaining({
+          pluginId: 'plugin-a',
+          version: '1.0.0',
+          etag: 'etag-a',
+          status: PluginStatusEnum.active,
+          updateAt: expect.any(Date)
+        }),
+        $unset: {
+          expiredAt: 1
+        }
+      }
+    );
+    expect(privateSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileKey: 'plugin-a/1.0.0/etag-a/index.js',
+        fileName: 'index.js'
+      })
+    );
+    expect(publicSave).not.toHaveBeenCalled();
+    expect(pluginModel.find).toHaveBeenCalledWith(
+      {
+        pluginId: 'plugin-a',
+        version: '1.0.0',
+        etag: {
+          $ne: 'etag-a'
+        },
+        status: PluginStatusEnum.active
+      },
+      {
+        _id: 0,
+        pluginId: 1,
+        version: 1,
+        etag: 1
+      }
+    );
+    expect(pluginModel.updateMany).toHaveBeenCalledWith(
+      {
+        $or: [
+          {
+            pluginId: 'plugin-a',
+            version: '1.0.0',
+            etag: 'old-etag'
+          }
+        ]
+      },
+      {
+        $set: {
+          status: PluginStatusEnum.disabled,
+          updateAt: expect.any(Date)
+        },
+        $unset: {
+          expiredAt: 1
+        }
+      }
+    );
+    expect(installationModel.deleteMany).toHaveBeenCalledWith({
+      $or: [
+        {
+          pluginId: 'plugin-a',
+          version: '1.0.0',
+          etag: 'old-etag'
+        }
+      ]
+    });
+    expect(installationModel.updateOne).toHaveBeenCalledWith(
+      {
+        source: 'system',
+        pluginId: 'plugin-a',
+        version: '1.0.0'
+      },
+      {
+        $set: {
+          etag: 'etag-a',
+          pluginObjectId: 'existing-plugin'
+        }
+      },
+      {
+        upsert: true
+      }
+    );
   });
 
   it('reports same version and etag when uploading an already installed plugin', async () => {

--- a/packages/infrastructure/src/plugin/plugin.repo.ts
+++ b/packages/infrastructure/src/plugin/plugin.repo.ts
@@ -184,6 +184,53 @@ export class PluginRepo implements PluginRepoPort {
     );
   }
 
+  private async disableSameVersionActivePlugins(uniqueId: PluginUniqueIdType): Promise<Result> {
+    try {
+      const activePlugins = await this.deps.mongoClient
+        .getModel('plugin')
+        .find(
+          {
+            pluginId: uniqueId.pluginId,
+            version: uniqueId.version,
+            etag: {
+              $ne: uniqueId.etag
+            },
+            status: PluginStatusEnum.active
+          },
+          {
+            _id: 0,
+            pluginId: 1,
+            version: 1,
+            etag: 1
+          }
+        )
+        .lean();
+
+      const replacedPluginIds = activePlugins.map((plugin) => PluginUniqueIdSchema.parse(plugin));
+      const [, disableErr] = await this.disablePlugins(replacedPluginIds);
+
+      if (disableErr) {
+        return failureResult(
+          {
+            en: 'Failed to disable same-version active plugins',
+            'zh-CN': '禁用同版本 active 插件失败'
+          },
+          disableErr
+        );
+      }
+
+      return successResult({});
+    } catch (error) {
+      return failureResult(
+        {
+          en: 'Failed to disable same-version active plugins',
+          'zh-CN': '禁用同版本 active 插件失败'
+        },
+        error
+      );
+    }
+  }
+
   private getManagedPublicFileNames(fileKeys: string[]): Set<string> {
     return new Set(fileKeys.map((fileKey) => path.basename(fileKey)));
   }
@@ -456,6 +503,9 @@ export class PluginRepo implements PluginRepoPort {
           }
         )
         .lean();
+
+      const [, replaceActiveErr] = await this.disableSameVersionActivePlugins(pluginId);
+      if (replaceActiveErr) return failureResult(replaceActiveErr);
 
       await this.updateSystemInstallation(plugin);
 
@@ -911,6 +961,7 @@ export class PluginRepo implements PluginRepoPort {
     let installedPlugin: MongoPluginWithId | undefined;
 
     try {
+      const pluginRecord = this.toPluginRecord(plugin);
       const existingPlugin = await pluginModel
         .findOne(uniqueId, {
           _id: true,
@@ -940,9 +991,25 @@ export class PluginRepo implements PluginRepoPort {
           return successResult({});
         } else if (!pending && existingPlugin.status === PluginStatusEnum.active) {
           installedPlugin = {
-            ...this.toPluginRecord(plugin),
+            ...pluginRecord,
             _id: existingPlugin._id
           } as MongoPluginWithId;
+        } else if (!pending && existingPlugin.status === PluginStatusEnum.disabled) {
+          installedPlugin = {
+            ...pluginRecord,
+            _id: existingPlugin._id
+          } as MongoPluginWithId;
+
+          await pluginModel.updateOne(uniqueId, {
+            $set: {
+              ...pluginRecord,
+              status: PluginStatusEnum.active,
+              updateAt: new Date()
+            },
+            $unset: {
+              expiredAt: 1
+            }
+          });
         } else {
           return failureResult({
             en: 'Plugin with the same version and etag already exists',
@@ -951,7 +1018,7 @@ export class PluginRepo implements PluginRepoPort {
         }
       } else {
         const createdPlugin = await pluginModel.create({
-          ...this.toPluginRecord(plugin),
+          ...pluginRecord,
           ...(pending
             ? {
                 status: PluginStatusEnum.pending,
@@ -1068,6 +1135,9 @@ export class PluginRepo implements PluginRepoPort {
       }
 
       if (!pending && installedPlugin) {
+        const [, replaceActiveErr] = await this.disableSameVersionActivePlugins(uniqueId);
+        if (replaceActiveErr) return failureResult(replaceActiveErr);
+
         try {
           await this.updateSystemInstallation(installedPlugin);
         } catch (error) {

--- a/packages/usecase/src/plugin/plugin-confirm.uc.ts
+++ b/packages/usecase/src/plugin/plugin-confirm.uc.ts
@@ -123,7 +123,8 @@ export const makePluginConfirmUC =
         const [, replaceErr] = await disableAndUnregisterReplacedPlugins({
           ...deps,
           replacementUniqueId: uniqueId,
-          replacedPlugins
+          replacedPlugins,
+          disableReplacedPlugins: false
         });
 
         if (replaceErr) {

--- a/packages/usecase/src/plugin/plugin-install.uc.ts
+++ b/packages/usecase/src/plugin/plugin-install.uc.ts
@@ -181,7 +181,8 @@ export const makePluginInstallUC =
           pluginRuntimeManager,
           logger,
           replacementUniqueId: uniqueId,
-          replacedPlugins
+          replacedPlugins,
+          disableReplacedPlugins: false
         });
 
         if (replaceErr) {

--- a/packages/usecase/src/plugin/plugin-replace-active.ts
+++ b/packages/usecase/src/plugin/plugin-replace-active.ts
@@ -38,6 +38,7 @@ export const disableAndUnregisterReplacedPlugins = async (deps: {
   logger: UsecaseLogger;
   replacementUniqueId?: PluginUniqueIdType;
   replacedPlugins: PluginType[];
+  disableReplacedPlugins?: boolean;
 }): Promise<Result> => {
   const replacedPluginIds = deps.replacedPlugins.map((plugin) =>
     PluginUniqueIdSchema.parse(plugin)
@@ -46,21 +47,23 @@ export const disableAndUnregisterReplacedPlugins = async (deps: {
     .filter((plugin) => plugin.type === 'tool')
     .map((plugin) => PluginUniqueIdSchema.parse(plugin));
 
-  const [, disableErr] = await deps.pluginRepo.disablePlugins(replacedPluginIds);
+  if (deps.disableReplacedPlugins !== false) {
+    const [, disableErr] = await deps.pluginRepo.disablePlugins(replacedPluginIds);
 
-  if (disableErr) {
-    const failure = failureResult(
-      {
-        en: 'Failed to disable replaced plugins',
-        'zh-CN': '禁用被替换插件失败'
-      },
-      disableErr
-    )[1]!;
-    deps.logger.error('Plugin Replace Active Disable Error', {
-      replacedPluginIds,
-      error: toUsecaseErrorLog(failure)
-    });
-    return [null, failure];
+    if (disableErr) {
+      const failure = failureResult(
+        {
+          en: 'Failed to disable replaced plugins',
+          'zh-CN': '禁用被替换插件失败'
+        },
+        disableErr
+      )[1]!;
+      deps.logger.error('Plugin Replace Active Disable Error', {
+        replacedPluginIds,
+        error: toUsecaseErrorLog(failure)
+      });
+      return [null, failure];
+    }
   }
 
   await Promise.all(

--- a/packages/usecase/src/usecase.test.ts
+++ b/packages/usecase/src/usecase.test.ts
@@ -1285,14 +1285,13 @@ describe('makePluginInstallUC', () => {
     expect(result?.failed?.[0]?.reason.en).toBe('Failed to get active plugins');
   });
 
-  it('reports create, register, and replace failures during installation', async () => {
+  it('reports create and register failures during installation', async () => {
     const deps = makeDeps({
       localFileStorageRepo: {
         save: vi
           .fn()
           .mockResolvedValueOnce(successResult(fileObject('create')))
           .mockResolvedValueOnce(successResult(fileObject('register')))
-          .mockResolvedValueOnce(successResult(fileObject('replace')))
       },
       pluginPKGFileResolver: {
         parsePluginZipFiles: vi.fn(),
@@ -1300,35 +1299,30 @@ describe('makePluginInstallUC', () => {
           .fn()
           .mockResolvedValueOnce(successResult(pluginPkgInfo(plugin({ pluginId: 'create' }))))
           .mockResolvedValueOnce(successResult(pluginPkgInfo(plugin({ pluginId: 'register' }))))
-          .mockResolvedValueOnce(successResult(pluginPkgInfo(plugin({ pluginId: 'replace' }))))
       },
       pluginRepo: basePluginRepo({
         listActive: vi.fn().mockResolvedValue(successResult([plugin({ etag: 'old' })])),
         createPlugin: vi
           .fn()
           .mockResolvedValueOnce(failureResult(reason('create failed')))
-          .mockResolvedValueOnce(successResult({}))
           .mockResolvedValueOnce(successResult({})),
         disablePlugins: vi.fn().mockResolvedValue(failureResult(reason('disable failed')))
       }),
       pluginRuntimeManager: baseRuntimeManager({
-        register: vi
-          .fn()
-          .mockResolvedValueOnce(failureResult(reason('register failed')))
-          .mockResolvedValueOnce(successResult({}))
+        register: vi.fn().mockResolvedValueOnce(failureResult(reason('register failed')))
       })
     });
 
     const [result] = await makePluginInstallUC(deps)({
-      urls: ['create-url', 'register-url', 'replace-url'],
+      urls: ['create-url', 'register-url'],
       batchDownloadSize: 1
     });
 
     expect(result?.failed?.map((item) => item.reason.en)).toEqual([
       'create failed',
-      'register failed',
-      'Failed to disable replaced plugins'
+      'register failed'
     ]);
+    expect(deps.pluginRepo.disablePlugins).not.toHaveBeenCalled();
   });
 
   it('returns full success after installing runnable and non-runnable plugin packages', async () => {
@@ -1373,7 +1367,7 @@ describe('makePluginInstallUC', () => {
     expect(err).toBeNull();
     expect(result).toEqual({});
     expect(deps.pluginRuntimeManager.register).toHaveBeenCalledTimes(1);
-    expect(deps.pluginRepo.disablePlugins).toHaveBeenCalledTimes(1);
+    expect(deps.pluginRepo.disablePlugins).not.toHaveBeenCalled();
     expect(deps.pluginRuntimeManager.unregister).toHaveBeenCalledWith(
       {
         pluginId: uniqueId.pluginId,
@@ -1482,19 +1476,30 @@ describe('makePluginConfirmUC', () => {
     expect(err?.reason.en).toBe('Failed to register confirmed plugin');
   });
 
-  it('returns failure when replaced plugins cannot be disabled', async () => {
+  it('does not disable replaced plugins again after repo confirm succeeds', async () => {
+    const oldPlugin = plugin({ etag: 'old' });
     const deps = makeDeps({
       pluginRepo: basePluginRepo({
-        listActive: vi.fn().mockResolvedValue(successResult([plugin({ etag: 'old' })])),
+        listActive: vi.fn().mockResolvedValue(successResult([oldPlugin])),
         getPendingPluginIds: vi.fn().mockResolvedValue(successResult([uniqueId])),
         confirmPlugin: vi.fn().mockResolvedValue(successResult(plugin())),
         disablePlugins: vi.fn().mockResolvedValue(failureResult(reason('disable failed')))
       })
     });
 
-    const [, err] = await makePluginConfirmUC(deps)({ uniqueIds: [uniqueId] });
+    const [result, err] = await makePluginConfirmUC(deps)({ uniqueIds: [uniqueId] });
 
-    expect(err?.reason.en).toBe('Failed to disable replaced plugins');
+    expect(err).toBeNull();
+    expect(result).toEqual({});
+    expect(deps.pluginRepo.disablePlugins).not.toHaveBeenCalled();
+    expect(deps.pluginRuntimeManager.unregister).toHaveBeenCalledWith(
+      {
+        pluginId: oldPlugin.pluginId,
+        version: oldPlugin.version,
+        etag: oldPlugin.etag
+      },
+      { replacementUniqueId: uniqueId }
+    );
   });
 
   it('confirms every runnable pending plugin successfully', async () => {


### PR DESCRIPTION
## Summary
- allow direct URL install to reactivate a disabled plugin with the target ETag
- enforce only one active ETag per pluginId/version by disabling replaced active plugins
- keep plugin_installations aligned by deleting old ETag installations and upserting the restored system installation
- keep usecase replacement cleanup focused on runtime unregister after repo-level DB replacement

## Tests
- ./node_modules/.bin/vitest run packages/infrastructure/src/plugin/plugin.repo.test.ts packages/usecase/src/usecase.test.ts
- ./node_modules/.bin/tsc --noEmit
- git diff --check