### PR TITLE
chore: add Mistral Devstral Small 2 preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/MistralAI/index.ts
@@ -143,6 +143,18 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'labs-devstral-small-2512',
+      maxContext: 256000,
+      maxTokens: 32000,
+      quoteMaxToken: 240000,
+      maxTemperature: 1.2,
+      vision: false,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'devstral-medium-2507',
       maxContext: 128000,
       maxTokens: 32000,


### PR DESCRIPTION
## Summary
- add the official Mistral Devstral Small 2 API ID `labs-devstral-small-2512`
- set the preset context to 256k and keep the existing Devstral chat/tooling fields

## Evidence
- Mistral models overview lists Devstral Small 2 and API ID `labs-devstral-small-2512`
- Mistral model card confirms the same API ID and 256k context

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider MistralAI` passed
- `bun run test` failed on existing sdk/factory zod metadata incompatibility: `z.string().meta is not a function`
- `bun tsc --noEmit` failed on the same existing zod v3 metadata/toJSONSchema type errors