### PR TITLE
chore: standardize Grok model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
@@ -5,31 +5,19 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'grok-4.5',
+      maxContext: 500000,
+      maxTokens: 8000,
+      quoteMaxToken: 500000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'grok-4.3',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-latest',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-4.3-latest',
       maxContext: 1000000,
       maxTokens: 8000,
       quoteMaxToken: 1000000,
@@ -53,43 +41,7 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'grok-4.20-multi-agent',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'grok-4.20-0309-reasoning',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-4.20-reasoning',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-4.20',
       maxContext: 1000000,
       maxTokens: 8000,
       quoteMaxToken: 1000000,
@@ -113,18 +65,6 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'grok-4.20-non-reasoning',
-      maxContext: 1000000,
-      maxTokens: 8000,
-      quoteMaxToken: 1000000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'grok-build-0.1',
       maxContext: 256000,
       maxTokens: 8000,
@@ -132,66 +72,6 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       vision: true,
       reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-code-fast',
-      maxContext: 256000,
-      maxTokens: 8000,
-      quoteMaxToken: 200000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: true,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-4',
-      maxContext: 256000,
-      maxTokens: 8000,
-      quoteMaxToken: 128000,
-      maxTemperature: 1,
-      vision: true,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-3-mini',
-      maxContext: 128000,
-      maxTokens: 8000,
-      quoteMaxToken: 128000,
-      maxTemperature: 1,
-      vision: false,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-3-mini-fast',
-      maxContext: 128000,
-      maxTokens: 8000,
-      quoteMaxToken: 128000,
-      maxTemperature: 1,
-      vision: false,
-      reasoning: false,
-      reasoningEffort: false,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'grok-3-fast',
-      maxContext: 128000,
-      maxTokens: 8000,
-      quoteMaxToken: 128000,
-      maxTemperature: 1,
-      vision: false,
-      reasoning: false,
       reasoningEffort: false,
       toolChoice: true
     }


### PR DESCRIPTION
## Summary
- add canonical xAI `grok-4.5` preset
- reduce Grok presets to current official canonical model names only
- remove alias/legacy entries such as `grok-latest`, `grok-4.3-latest`, `grok-code-fast`, `grok-4`, and `grok-3-*`

## Retained Grok model IDs
- `grok-4.5`
- `grok-4.3`
- `grok-4.20-multi-agent-0309`
- `grok-4.20-0309-reasoning`
- `grok-4.20-0309-non-reasoning`
- `grok-build-0.1`

## Sources
- https://docs.x.ai/developers/models.md
- https://docs.x.ai/developers/models/grok-4.5.md
- https://docs.x.ai/developers/models/grok-4.3.md
- https://docs.x.ai/developers/models/grok-build-0.1.md

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider Grok`
- `git diff --check`
- `pnpm exec eslint --fix packages/infrastructure/src/static-data/models/provider/Grok/index.ts`
- pre-commit `eslint --fix` passed
- `bun run test` fails in existing `sdk/factory/src/tool-factory.test.ts:329` because installed zod v3 lacks `.meta()`; unrelated to this static Grok preset change
- `bun tsc --noEmit` fails in existing SDK/zod metadata and `sdk/factory/src/tool-factory.test.ts:285` stream type errors; unrelated to this static Grok preset change