### PR TITLE
chore: update OpenAI model presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts
@@ -64,6 +64,58 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'gpt-5.6',
+      maxContext: 1050000,
+      maxTokens: 128000,
+      quoteMaxToken: 1000000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gpt-5.6-sol',
+      maxContext: 1050000,
+      maxTokens: 128000,
+      quoteMaxToken: 1000000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gpt-5.6-terra',
+      maxContext: 1050000,
+      maxTokens: 128000,
+      quoteMaxToken: 1000000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gpt-5.6-luna',
+      maxContext: 1050000,
+      maxTokens: 128000,
+      quoteMaxToken: 1000000,
+      maxTemperature: null,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gpt-5.5',
       maxContext: 1050000,
       maxTokens: 128000,


### PR DESCRIPTION
## Summary
- Add OpenAI GPT-5.6 model presets: `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- Keep the presets ordered newest-first and reuse the existing GPT-5.5 family capability fields.

## Evidence
- Official OpenAI model docs: https://platform.openai.com/docs/models
- Checked on 2026-07-12.

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory --provider OpenAI`
- `pnpm exec eslint packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts`
- `git diff --check`
- `pnpm exec tsx -e "...import OpenAI provider and assert GPT-5.6 models..."`

## Known existing validation failures
- `bun tsc --noEmit` currently fails in `sdk/factory` with existing Zod API/version errors (`GlobalMeta`, `.meta`, `toJSONSchema`).
- `bun run test` currently fails one existing `sdk/factory/src/tool-factory.test.ts` schema metadata test for `z.string().meta is not a function`; it also warns that `.env.test` is missing.
