### PR TITLE
chore: add Groq Qwen3.6 preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Groq/index.ts
@@ -40,6 +40,18 @@ const models: ProviderConfigType = {
       toolChoice: true
     },
     {
+      type: ModelTypeEnum.llm,
+      model: 'qwen/qwen3.6-27b',
+      maxContext: 131072,
+      maxTokens: 32768,
+      quoteMaxToken: 120000,
+      maxTemperature: 1.2,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
       type: ModelTypeEnum.stt,
       model: 'whisper-large-v3'
     },


### PR DESCRIPTION
## Summary
- Add Groq `qwen/qwen3.6-27b` LLM preset.
- Set the preset from Groq official model data: 131,072 context, 32,768 max output tokens, vision enabled, reasoning enabled, and tool choice enabled.

## Evidence
- Groq model list: https://console.groq.com/docs/models
- Groq Qwen3.6 model card: https://console.groq.com/docs/model/qwen/qwen3.6-27b

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory`
- `bun run test` passed: 39 files / 246 tests. Existing warnings: missing optional `.env.test` / `.env.test.local`, and Vitest coverage package version mismatch.
- `bunx tsx -e "...ProviderConfigSchema.parse(groq)..."` passed for the Groq provider data.
- `bun tsc --noEmit` currently fails on existing `sdk/factory/src/tool-factory.test.ts(285,9)` stream mock typing; this is unrelated to the static Groq preset change.
