### PR TITLE
fix: align multimodal model capabilities

### DIFF
--- a/packages/domain/src/entities/model.entity.ts
+++ b/packages/domain/src/entities/model.entity.ts
@@ -37,6 +37,8 @@ export const LLMModelItemSchema = z.object({
 
   censor: z.boolean().optional(),
   vision: z.boolean(),
+  audio: z.boolean().optional(),
+  video: z.boolean().optional(),
   reasoning: z.boolean(),
   reasoningEffort: z.boolean(),
   toolChoice: z.boolean(),

--- a/packages/infrastructure/src/static-data/models/provider/Doubao/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Doubao/index.ts
@@ -16,6 +16,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1024000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -28,6 +29,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 256000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -40,6 +42,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 256000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -52,6 +55,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 256000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -64,6 +68,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 256000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -76,6 +81,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 224000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -88,6 +94,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 224000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -100,6 +108,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 224000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -112,6 +121,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 224000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -124,6 +135,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 224000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -136,6 +148,7 @@ const models: ProviderConfigType = {
       quoteMaxToken: 224000,
       maxTemperature: 1,
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true

--- a/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
@@ -11,6 +11,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -23,6 +25,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -35,6 +39,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -47,6 +53,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -59,6 +67,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -71,6 +81,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -83,6 +95,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -95,6 +109,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true
@@ -107,6 +123,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true
@@ -119,6 +137,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       vision: true,
+      audio: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true

--- a/packages/infrastructure/src/static-data/models/provider/Qwen/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Qwen/index.ts
@@ -16,7 +16,8 @@ const models: ProviderConfigType = {
       quoteMaxToken: 1000000,
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object', 'json_schema'],
-      vision: false,
+      vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -30,6 +31,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -56,6 +58,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -69,6 +72,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -82,6 +86,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -95,6 +100,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object', 'json_schema'],
       vision: true,
+      video: true,
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
@@ -121,6 +127,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object'],
       vision: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true
@@ -134,6 +141,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object'],
       vision: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: true
@@ -160,6 +168,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object'],
       vision: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: false
@@ -186,6 +195,7 @@ const models: ProviderConfigType = {
       maxTemperature: 1,
       responseFormatList: ['text', 'json_object'],
       vision: true,
+      video: true,
       reasoning: false,
       reasoningEffort: false,
       toolChoice: false

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type LLMModelItemType,
+  ModelItemSchema,
+  ModelTypeEnum
+} from '@domain/entities/model.entity';
+
+import doubao from './Doubao';
+import gemini from './Gemini';
+import qwen from './Qwen';
+
+const staticModelList = [gemini, qwen, doubao].flatMap((provider) =>
+  provider.list.map((model) =>
+    ModelItemSchema.parse({
+      ...model,
+      provider: provider.provider,
+      name: model.name ?? model.model
+    })
+  )
+);
+
+const getModel = (provider: string, model: string) =>
+  staticModelList.find((item) => item.provider === provider && item.model === model);
+
+describe('static model multimodal capabilities', () => {
+  it('marks Gemini LLMs as supporting image, audio, and video inputs', () => {
+    const llms = staticModelList.filter(
+      (item): item is LLMModelItemType =>
+        item.provider === 'Gemini' && item.type === ModelTypeEnum.llm
+    );
+
+    expect(llms).not.toHaveLength(0);
+    expect(llms.every((model) => model.vision && model.audio && model.video)).toBe(true);
+  });
+
+  it('marks Qwen visual models with their video input capability', () => {
+    expect(getModel('Qwen', 'qwen3.7-max')).toMatchObject({
+      vision: true,
+      video: true
+    });
+    expect(getModel('Qwen', 'qwen3.7-plus')).toMatchObject({
+      vision: true,
+      video: true
+    });
+    expect(getModel('Qwen', 'qwen3-vl-plus')).toMatchObject({
+      vision: true,
+      video: true
+    });
+    expect(getModel('Qwen', 'qwen-vl-max')).toMatchObject({
+      vision: true,
+      video: true
+    });
+    expect(getModel('Qwen', 'qwen3-max')).toMatchObject({ vision: false });
+  });
+
+  it('distinguishes Doubao audio-capable versions from video-only versions', () => {
+    expect(getModel('Doubao', 'doubao-seed-evolving')).toMatchObject({
+      vision: true,
+      video: true
+    });
+    expect(getModel('Doubao', 'doubao-seed-2-0-lite-260428')).toMatchObject({
+      vision: true,
+      audio: true,
+      video: true
+    });
+    expect(getModel('Doubao', 'doubao-seed-2-0-mini-260428')).toMatchObject({
+      vision: true,
+      audio: true,
+      video: true
+    });
+    expect(getModel('Doubao', 'doubao-seed-2-0-pro-260215')).not.toHaveProperty('audio');
+  });
+});


### PR DESCRIPTION
## Summary

- add `audio` and `video` capability fields to the static LLM model schema
- mark Gemini chat models as supporting image, audio, and video inputs
- align Qwen and Doubao image, video, and audio flags with their official model catalogs
- add regression coverage for the published multimodal capability metadata

## Why

FastGPT now distinguishes image, audio, and video model inputs, but the plugin registry only exposed the legacy `vision` flag. As a result, supported audio and video uploads were not advertised for these provider presets.

## Validation

- `bun run test` (40 test files, 249 tests passed)
- targeted TypeScript validation for the model schema and provider presets
- `pnpm exec eslint` on all changed files
- `git diff --check`

## Notes

The repository-wide `bun tsc --noEmit` still reports the existing `sdk/factory/src/tool-factory.test.ts` duplicated `StreamData` type incompatibility. No SDK factory files are changed by this PR.