### PR TITLE
feat: add Tencent Hy3 model preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Hunyuan/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Hunyuan/index.ts
@@ -5,6 +5,19 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'hy3',
+      maxContext: 256000,
+      maxTokens: 128000,
+      quoteMaxToken: 192000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object', 'json_schema'],
+      vision: false,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'hunyuan-large',
       maxContext: 28000,
       maxTokens: 4000,


### PR DESCRIPTION
## Summary

- Rebase the PR branch onto the latest `upstream/main` at `f226e95`.
- Add Tencent TokenHub's formal `hy3` model preset to the existing Hunyuan provider.
- Configure the official 256K context window, 192K maximum input, 128K maximum output, reasoning effort, structured output, and function calling capabilities.
- Keep the model audit strictly add-only: no existing presets are removed, and `hy3-preview` is not added.
- Keep the requested exclusions unchanged: `gpt-5.3-codex`, `o3-pro`, and `qwen3.8-max-preview` remain absent; formal `qwen3.8-max` remains present.

## Rebase result

- The null-temperature fix is now part of `main` through PR #523, so its duplicate branch commits were dropped during rebase.
- The final PR diff contains only the 13-line Hunyuan `hy3` addition.
- Final inventory: 34 providers, 295 model presets, no duplicate model IDs.

## Verification

- Targeted Hunyuan ESLint, inventory validation, and `git diff --check` passed after rebase.
- Previous full test run passed: 43 files and 266 tests.
- `bun tsc --noEmit` still reports the pre-existing `sdk/factory/src/tool-factory.test.ts:285` type mismatch.

## Official sources

- Tencent TokenHub model list: https://cloud.tencent.com/document/product/1823/130051
- Tencent Hy3 API guide: https://cloud.tencent.com/document/product/1823/132252
