### PR TITLE
feat: update current model provider presets

### DIFF
--- a/.codex/skills/model-provider-updater/references/provider_sources.json
+++ b/.codex/skills/model-provider-updater/references/provider_sources.json
@@ -1,10 +1,10 @@
 {
   "OpenAI": {
-    "docs": ["https://platform.openai.com/docs/models"],
+    "docs": ["https://developers.openai.com/api/docs/models"],
     "notes": "Use official OpenAI model docs or authenticated model-list API if credentials are explicitly available."
   },
   "Claude": {
-    "docs": ["https://docs.anthropic.com/en/docs/about-claude/models"],
+    "docs": ["https://platform.claude.com/docs/en/about-claude/models/overview"],
     "notes": "Anthropic documents current model IDs and aliases on the models page."
   },
   "Gemini": {
@@ -12,11 +12,11 @@
     "notes": "Use Gemini API model docs or official list models API."
   },
   "Grok": {
-    "docs": ["https://docs.x.ai/docs/models"],
+    "docs": ["https://docs.x.ai/developers/models"],
     "notes": "Use xAI model docs."
   },
   "MistralAI": {
-    "docs": ["https://docs.mistral.ai/getting-started/models/models_overview/"],
+    "docs": ["https://docs.mistral.ai/models"],
     "notes": "Use Mistral model overview and API docs."
   },
   "Qwen": {
@@ -32,7 +32,7 @@
     "notes": "Use DeepSeek API docs and pricing/model page."
   },
   "ChatGLM": {
-    "docs": ["https://docs.bigmodel.cn/cn/guide/models"],
+    "docs": ["https://docs.bigmodel.cn/cn/guide/start/model-overview"],
     "notes": "Use Zhipu BigModel model docs."
   },
   "MiniMax": {
@@ -52,8 +52,8 @@
     "notes": "Use iFlytek Spark official docs."
   },
   "Hunyuan": {
-    "docs": ["https://cloud.tencent.com/document/product/1729"],
-    "notes": "Use Tencent Hunyuan official docs."
+    "docs": ["https://cloud.tencent.com/document/product/1823/132252"],
+    "notes": "Use Tencent TokenHub's official Hy model docs."
   },
   "Baichuan": {
     "docs": ["https://platform.baichuan-ai.com/docs"],

--- a/packages/infrastructure/src/static-data/models/provider/Ernie/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Ernie/index.ts
@@ -17,6 +17,18 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'ernie-x1.1',
+      maxContext: 64000,
+      maxTokens: 65536,
+      quoteMaxToken: 55000,
+      maxTemperature: 1,
+      vision: false,
+      reasoning: true,
+      reasoningEffort: false,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'ernie-5.0',
       maxContext: 128000,
       maxTokens: 65536,

--- a/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Grok/index.ts
@@ -17,6 +17,18 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'grok-4.6',
+      maxContext: 500000,
+      maxTokens: 8000,
+      quoteMaxToken: 500000,
+      maxTemperature: 1,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'grok-4.3',
       maxContext: 1000000,
       maxTokens: 8000,


### PR DESCRIPTION
## Summary

- continue the strict add-only model audit on `codex/model-provider-audit-20260813`, based on the latest `upstream/main` (`abb1188`)
- retain the existing official xAI `grok-4.6` and Baidu Qianfan `ernie-x1.1` presets
- retain the source-link refresh from the previous commit
- complete the 2026-08-15 recheck without adding or removing any preset

## Model audit

- 32 of 34 registered providers checked against current official catalogs; Moka and Other remain pending because they have no concrete official catalog hints
- inventory remains at 297 presets across 34 registered providers, with no duplicate model IDs across or within providers
- all executable plan `remove` arrays remain empty
- current official candidates that were not added were preview, invitation-only, dated snapshot, region-specific, modality-specific, third-party-hosted, or parameter-scale/open-checkpoint models under the updater policy
- requested exclusions remain absent: `gpt-5.3-codex`, `o3-pro`, and `qwen3.8-max-preview`

## Existing changes

- `grok-4.6`: 500K context, text/image input, reasoning, structured outputs, and function calling
- `ernie-x1.1`: 64K context, 55K maximum input, 64K maximum output, reasoning, and tool calling

## Validation

- `bun run test` (43 files, 266 tests)
- targeted ESLint for the changed provider files
- model inventory and duplicate-ID validation
- model-provider plan dry-run and write, with zero operations this recheck
- source-hint check (all configured sources reachable; SparkDesk returns acceptable access-limited 403)
- `git diff --check`
- `bun tsc --noEmit` still reports the existing unrelated error at `sdk/factory/src/tool-factory.test.ts:285`

## Official sources

- [OpenAI model catalog](https://developers.openai.com/api/docs/models/all)
- [Claude model overview](https://platform.claude.com/docs/en/about-claude/models/overview)
- [Gemini model catalog](https://ai.google.dev/gemini-api/docs/models)
- [xAI model catalog](https://docs.x.ai/developers/models)
- [Mistral model overview](https://docs.mistral.ai/models)
- [Alibaba Cloud Model Studio text models](https://help.aliyun.com/zh/model-studio/text-generation-model)
- [Baidu Qianfan model list](https://cloud.baidu.com/doc/qianfan/s/rmh4stp0j)
- [Tencent TokenHub Hy guide](https://cloud.tencent.com/document/product/1823/132252)
- [Zhipu model overview](https://docs.bigmodel.cn/cn/guide/start/model-overview)
- [Kimi model list](https://platform.kimi.ai/docs/models)
- [DeepSeek models and pricing](https://api-docs.deepseek.com/quick_start/pricing)
- [StepFun model overview](https://platform.stepfun.com/docs/zh/guides/models/overview)
