### PR TITLE
ci: optimize plugin image workflows

### DIFF
--- a/.github/workflows/build-connection-gateway.yml
+++ b/.github/workflows/build-connection-gateway.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: build-connection-gateway-${{ github.ref }}
@@ -14,6 +13,9 @@ concurrency:
 jobs:
   build-image:
     name: Build ${{ matrix.archs.arch }} Connection Gateway image
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -22,13 +24,27 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.archs.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: |
+            network=host
+
+      - name: Cache Docker layers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.archs.arch }}-connection-gateway-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.archs.arch }}-connection-gateway-buildx-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -37,50 +53,96 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push for ${{ matrix.archs.arch }}
-        id: build
+      - name: Login to Ali Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
+      - name: Build and push to GitHub Container Registry for ${{ matrix.archs.arch }}
+        id: build-ghcr
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: apps/connection-gateway/Dockerfile
           target: runner
           platforms: linux/${{ matrix.archs.arch }}
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-connection-gateway:${{ github.sha }}-${{ matrix.archs.arch }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-connection-gateway",push-by-digest=true,push=true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.description=FastGPT Plugin Connection Gateway image
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha,scope=connection-gateway-${{ matrix.archs.arch }}
-          cache-to: type=gha,mode=max,scope=connection-gateway-${{ matrix.archs.arch }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
+      - name: Build and push to Ali Hub for ${{ matrix.archs.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          name: connection-gateway-digests-${{ matrix.archs.arch }}
-          path: /tmp/digests/*
+          context: .
+          file: apps/connection-gateway/Dockerfile
+          target: runner
+          platforms: linux/${{ matrix.archs.arch }}
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-plugin-connection-gateway",push-by-digest=true,push=true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=FastGPT Plugin Connection Gateway image
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+
+      - name: Export digests
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests/ghcr" "${{ runner.temp }}/digests/aliyun"
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          [[ "$ghcr_digest" == sha256:* ]] || { echo "::error::Missing GHCR image digest"; exit 1; }
+          [[ "$aliyun_digest" == sha256:* ]] || { echo "::error::Missing Ali Hub image digest"; exit 1; }
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
+
+      - name: Upload GHCR digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: connection-gateway-ghcr-digests-${{ matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: connection-gateway-aliyun-digests-${{ matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
           if-no-files-found: error
           retention-days: 1
 
   merge-image:
     name: Publish multi-arch Connection Gateway image
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-24.04
     needs:
       - build-image
+    timeout-minutes: 120
 
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
+      - name: Download GHCR digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/digests
-          pattern: connection-gateway-digests-*
+          pattern: connection-gateway-ghcr-digests-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: /tmp/digests/aliyun
+          pattern: connection-gateway-aliyun-digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -106,18 +168,71 @@ jobs:
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
           password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
 
-      - name: Create manifest list and push
+      - name: Create manifest lists and push
         working-directory: /tmp/digests
+        timeout-minutes: 120
         run: |
-          GITHUB_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-connection-gateway"
+          set -euo pipefail
+
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-connection-gateway"
           ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-plugin-connection-gateway"
           DOCKER_IMAGE="${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-plugin-connection-gateway"
 
-          TAGS="$GITHUB_IMAGE:${{ github.sha }} $ALI_IMAGE:${{ github.sha }} $DOCKER_IMAGE:${{ github.sha }}"
-
-          for TAG in $TAGS; do
-            echo "Creating manifest list for: $TAG"
-            docker buildx imagetools create -t "$TAG" \
-              $(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-connection-gateway@sha256:%s ' *)
-            sleep 2
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
           done
+
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "::error::Expected exactly two GHCR and two Ali Hub digests."
+            exit 1
+          fi
+
+          retry_imagetools_create() {
+            local tag="$1"
+            shift
+
+            for attempt in 1 2 3 4; do
+              if docker buildx imagetools create -t "$tag" "$@"; then
+                return 0
+              fi
+
+              if [[ "$attempt" -eq 4 ]]; then
+                echo "::error::Failed to push manifest ${tag} after 3 retries."
+                return 1
+              fi
+
+              echo "::warning::Failed to push manifest ${tag}; retrying in $((attempt * 15)) seconds (${attempt}/3)."
+              sleep $((attempt * 15))
+            done
+          }
+
+          for TAG in \
+            "${GHCR_IMAGE}:${{ github.sha }}" \
+            "${DOCKER_IMAGE}:${{ github.sha }}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
+            sleep 5
+          done
+
+          retry_imagetools_create "${ALI_IMAGE}:${{ github.sha }}" "${ALI_SOURCES[@]}"
+
+          verify_manifest() {
+            local tag="$1"
+            local manifest
+            manifest="$(docker buildx imagetools inspect --raw "$tag")"
+            jq -e '
+              ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+              ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+              ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+            ' <<<"$manifest" >/dev/null
+          }
+
+          verify_manifest "${GHCR_IMAGE}:${{ github.sha }}"
+          verify_manifest "${ALI_IMAGE}:${{ github.sha }}"

--- a/.github/workflows/preview-image-build.yml
+++ b/.github/workflows/preview-image-build.yml
@@ -3,21 +3,10 @@ name: Preview Plugin Image Build
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: ['**']
-    paths:
-      - 'Dockerfile'
-      - '.dockerignore'
-      - 'apps/server/**'
-      - 'packages/**'
-      - 'sdk/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.github/workflows/preview-image-build.yml'
-      - '.github/workflows/preview-image-push.yml'
+    branches: ["**"]
 
 concurrency:
-  group: preview-plugin-image-build-${{ github.event.pull_request.number || github.head_ref }}
+  group: "preview-plugin-image-build-${{ github.event.pull_request.number }}"
   cancel-in-progress: true
 
 permissions:
@@ -27,19 +16,21 @@ jobs:
   build:
     name: Build preview Server image
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
 
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image artifact
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile
@@ -47,27 +38,19 @@ jobs:
           platforms: linux/amd64
           push: false
           tags: fastgpt-plugin-pr:${{ github.event.pull_request.head.sha }}
+          provenance: false
+          sbom: false
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.description=FastGPT Plugin PR preview image
             org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
           outputs: type=docker,dest=/tmp/fastgpt-plugin-image.tar
-          cache-from: type=gha,scope=preview-plugin-server
-          cache-to: type=gha,mode=max,scope=preview-plugin-server
-
-      - name: Save PR metadata
-        run: |
-          echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
-          echo "${{ github.event.pull_request.head.sha }}" > /tmp/pr-sha.txt
-          echo "server" > /tmp/image-type.txt
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: preview-plugin-server-image
-          path: |
-            /tmp/fastgpt-plugin-image.tar
-            /tmp/pr-number.txt
-            /tmp/pr-sha.txt
-            /tmp/image-type.txt
+          path: /tmp/fastgpt-plugin-image.tar
+          compression-level: 0
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/preview-image-push.yml
+++ b/.github/workflows/preview-image-push.yml
@@ -2,125 +2,265 @@ name: Preview Plugin Image Push
 
 on:
   workflow_run:
-    workflows: ['Preview Plugin Image Build']
+    workflows: ["Preview Plugin Image Build"]
     types: [completed]
+  issue_comment:
+    types: [created]
 
+# A newer automatic preview cancels an older publication; untrusted comments cannot cancel a running publish.
 concurrency:
-  group: preview-plugin-image-push
-  cancel-in-progress: false
+  group: "preview-plugin-image-push-${{ github.event.issue.number || github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch || github.run_id }}"
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: write
+  issues: write
 
 jobs:
-  check_pr_author:
-    name: Check trusted PR author
+  prepare:
+    name: Resolve preview build and publish permission
     runs-on: ubuntu-24.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
-      pull-requests: read
       actions: read
+      pull-requests: write
+      issues: write
     outputs:
-      trusted: ${{ steps.trust.outputs.trusted }}
-      should_publish: ${{ steps.trust.outputs.should_publish }}
-      number: ${{ steps.trust.outputs.number }}
-      sha: ${{ steps.trust.outputs.sha }}
+      should_publish: ${{ steps.prepare.outputs.should_publish }}
+      number: ${{ steps.prepare.outputs.number }}
+      sha: ${{ steps.prepare.outputs.sha }}
+      run_id: ${{ steps.prepare.outputs.run_id }}
+      manual: ${{ steps.prepare.outputs.manual }}
+      matrix: ${{ steps.prepare.outputs.matrix }}
 
     steps:
-      - name: Check trusted PR author
-        id: trust
-        uses: actions/github-script@v7
+      - name: Resolve preview build and publish permission
+        id: prepare
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const allowedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
-            const workflowRun = context.payload.workflow_run;
-            let prNumber = workflowRun.pull_requests?.[0]?.number;
+            const emptyMatrix = JSON.stringify({
+              include: [{ image: 'noop', artifact_name: 'noop', image_name: 'noop' }]
+            });
+            const artifactConfigs = [
+              { image: 'server', artifact_name: 'preview-plugin-server-image', image_name: 'fastgpt-plugin' }
+            ];
 
-            core.setOutput('trusted', 'false');
-            core.setOutput('should_publish', 'false');
-
-            if (!prNumber) {
-              const headOwner = workflowRun.head_repository?.owner?.login;
-              const headBranch = workflowRun.head_branch;
-
-              if (headOwner && headBranch) {
-                core.info(`workflow_run payload did not include a PR number; looking up PR by ${headOwner}:${headBranch}.`);
-                const { data: pullRequests } = await github.rest.pulls.list({
+            const hasPublishPermission = async (username) => {
+              if (!username) return false;
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  state: 'open',
-                  head: `${headOwner}:${headBranch}`
+                  username
                 });
-                const matchedPullRequest = pullRequests.find((pullRequest) =>
-                  pullRequest.head.sha === workflowRun.head_sha
-                ) ?? pullRequests[0];
-                prNumber = matchedPullRequest?.number;
+                return ['admin', 'maintain', 'write'].includes(data.permission);
+              } catch (error) {
+                core.warning(`Unable to resolve repository permission for ${username}: ${error.message}`);
+                return false;
               }
-            }
+            };
 
-            if (!prNumber) {
-              core.warning('No pull request was found on the workflow_run payload. Skipping privileged preview publish.');
+            const setDefaultOutputs = () => {
+              core.setOutput('should_publish', 'false');
+              core.setOutput('matrix', emptyMatrix);
+              core.setOutput('manual', 'false');
+            };
+
+            const upsertComment = async (issueNumber, marker, body) => {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber
+              });
+              const existingComment = comments.find((comment) => comment.body.includes(marker));
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body
+                });
+              }
+            };
+
+            const findBuildRun = async (sha) => {
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'preview-image-build.yml',
+                event: 'pull_request',
+                status: 'completed',
+                per_page: 100
+              });
+              return workflowRuns.find((run) =>
+                run.head_sha === sha && run.conclusion === 'success'
+              );
+            };
+
+            const getArtifacts = async (runId) => {
+              const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100
+              });
+              const artifactNames = new Set(artifacts.map((artifact) => artifact.name));
+              return artifactConfigs.filter((config) => artifactNames.has(config.artifact_name));
+            };
+
+            setDefaultOutputs();
+
+            let prNumber;
+            let sha;
+            let runId;
+            let manual = false;
+
+            if (context.eventName === 'workflow_run') {
+              const workflowRun = context.payload.workflow_run;
+              if (workflowRun.conclusion !== 'success') {
+                core.info(`Build workflow concluded with ${workflowRun.conclusion}; skipping preview publish.`);
+                return;
+              }
+
+              runId = workflowRun.id;
+              sha = workflowRun.head_sha;
+              prNumber = workflowRun.pull_requests?.[0]?.number;
+
+              if (!prNumber) {
+                const headOwner = workflowRun.head_repository?.owner?.login;
+                const headBranch = workflowRun.head_branch;
+                if (headOwner && headBranch) {
+                  const { data: pullRequests } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: 'open',
+                    head: `${headOwner}:${headBranch}`
+                  });
+                  const matchedPullRequest = pullRequests.find((pullRequest) =>
+                    pullRequest.head.sha === sha
+                  ) ?? pullRequests[0];
+                  prNumber = matchedPullRequest?.number;
+                }
+              }
+
+              if (!prNumber) {
+                core.warning('No pull request was found for the completed preview build.');
+                return;
+              }
+
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (pullRequest.state !== 'open' || pullRequest.head.sha !== sha) {
+                core.info(`Skipping stale preview build ${sha}; the current PR head is ${pullRequest.head.sha}.`);
+                return;
+              }
+
+              if (!await hasPublishPermission(pullRequest.user.login)) {
+                await upsertComment(prNumber, '<!-- fastgpt-plugin-preview-manual -->', `<!-- fastgpt-plugin-preview-manual -->
+            ✅ Preview image built successfully for \`${sha}\`.
+
+            Automatic publishing is disabled for this PR. A maintainer can comment:
+
+            \`/preview push\`
+
+            to publish the image from this exact build.`);
+                core.warning(`PR #${prNumber} author does not have repository publish permission; waiting for a maintainer comment before publishing.`);
+                return;
+              }
+            } else if (context.eventName === 'issue_comment') {
+              const issue = context.payload.issue;
+              const comment = context.payload.comment;
+              if (!issue.pull_request || comment.body.trim() !== '/preview push') {
+                return;
+              }
+
+              if (!await hasPublishPermission(comment.user.login)) {
+                core.warning(`Comment author ${comment.user.login} does not have repository publish permission.`);
+                return;
+              }
+
+              prNumber = issue.number;
+              manual = true;
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (pullRequest.state !== 'open') {
+                core.info(`PR #${prNumber} is not open; skipping manual preview publish.`);
+                return;
+              }
+
+              sha = pullRequest.head.sha;
+              const buildRun = await findBuildRun(sha);
+              if (!buildRun) {
+                await upsertComment(prNumber, '<!-- fastgpt-plugin-preview-manual -->', `<!-- fastgpt-plugin-preview-manual -->
+            ⚠️ No successful preview build was found for the current PR commit \`${sha}\`. Please wait for the build workflow to finish, then comment \`/preview push\` again.`);
+                return;
+              }
+              runId = buildRun.id;
+            } else {
               return;
             }
 
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-
-            const trusted = allowedAssociations.has(pullRequest.author_association);
-            core.setOutput('trusted', trusted ? 'true' : 'false');
-            core.setOutput('number', String(pullRequest.number));
-            core.setOutput('sha', pullRequest.head.sha);
-
-            if (!trusted) {
-              core.warning(`PR #${pullRequest.number} author association is ${pullRequest.author_association}; skipping privileged preview publish.`);
+            const images = await getArtifacts(runId);
+            if (images.length === 0) {
+              core.warning(`No preview image artifacts were found for workflow run ${runId}.`);
               return;
             }
 
-            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: workflowRun.id,
-              per_page: 100
-            });
-            const artifactNames = new Set(artifacts.map((artifact) => artifact.name));
-            const shouldPublish = artifactNames.has('preview-plugin-server-image');
-
-            core.setOutput('should_publish', shouldPublish ? 'true' : 'false');
-            core.info(`PR #${pullRequest.number} author association is ${pullRequest.author_association}; preview server image publish=${shouldPublish}.`);
+            core.setOutput('should_publish', 'true');
+            core.setOutput('number', String(prNumber));
+            core.setOutput('sha', sha);
+            core.setOutput('run_id', String(runId));
+            core.setOutput('manual', manual ? 'true' : 'false');
+            core.setOutput('matrix', JSON.stringify({ include: images }));
+            core.info(`Preview images to publish: ${images.map((image) => image.image).join(', ')}`);
 
   push:
     name: Push preview Server image
-    needs: check_pr_author
+    needs: prepare
+    if: ${{ needs.prepare.outputs.should_publish == 'true' }}
     runs-on: ubuntu-24.04
-    if: ${{ needs.check_pr_author.outputs.trusted == 'true' && needs.check_pr_author.outputs.should_publish == 'true' }}
     permissions:
       contents: read
       packages: write
       pull-requests: write
       issues: write
       actions: read
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 3
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: preview-plugin-server-image
+          name: ${{ matrix.artifact_name }}
           path: /tmp
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ needs.prepare.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load Docker image
-        run: docker load --input /tmp/fastgpt-plugin-image.tar
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        run: docker load --input /tmp/${{ matrix.image_name }}-image.tar
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -128,7 +268,7 @@ jobs:
 
       - name: Tag and push Docker image
         run: |
-          SHA="${{ needs.check_pr_author.outputs.sha }}"
+          SHA="${{ needs.prepare.outputs.sha }}"
           PREVIEW_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-pr:server_${SHA}"
           docker tag "fastgpt-plugin-pr:${SHA}" "${PREVIEW_IMAGE}"
           docker push "${PREVIEW_IMAGE}"
@@ -139,33 +279,32 @@ jobs:
           echo "value=$(TZ='Asia/Shanghai' date '+%Y-%m-%d %H:%M:%S (UTC+8)')" >> "$GITHUB_OUTPUT"
 
       - name: Add PR comment on success
-        if: success() && needs.check_pr_author.outputs.number != ''
-        uses: actions/github-script@v7
+        if: success() && needs.prepare.outputs.number != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const prNumber = parseInt('${{ needs.check_pr_author.outputs.number }}', 10);
+            const prNumber = parseInt('${{ needs.prepare.outputs.number }}', 10);
             const marker = '<!-- fastgpt-plugin-preview-server -->';
-            const image = 'ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-pr:server_${{ needs.check_pr_author.outputs.sha }}';
+            const mode = '${{ needs.prepare.outputs.manual }}' === 'true'
+              ? 'Manual publish successful'
+              : 'Build and publish successful';
+            const image = 'ghcr.io/${{ github.repository_owner }}/fastgpt-plugin-pr:server_${{ needs.prepare.outputs.sha }}';
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber
             });
-
-            const existingComment = comments.find((comment) =>
-              comment.body.includes(marker)
-            );
-
+            const existingComment = comments.find((comment) => comment.body.includes(marker));
             const commentBody = [
               marker,
-              '**Build Successful** - Preview Server image for this PR:',
+              `✅ **${mode}** - Preview Server image:`,
               '',
               '```',
               image,
               '```',
               '',
-              'Time: ${{ steps.preview_time.outputs.value }}'
+              '🕒 Time: ${{ steps.preview_time.outputs.value }}'
             ].join('\n');
 
             if (existingComment) {

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: release-image-${{ github.event.release.tag_name || github.ref_name }}
@@ -21,6 +20,9 @@ concurrency:
 jobs:
   build-image:
     name: Build ${{ matrix.archs.arch }} image
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -29,93 +31,37 @@ jobs:
           - arch: arm64
             runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.archs.runs-on || 'ubuntu-24.04' }}
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: |
+            network=host
+
+      - name: Cache Docker layers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.archs.arch }}-fastgpt-plugin-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.archs.arch }}-fastgpt-plugin-buildx-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Resolve image version
-        id: version
-        run: |
-          VERSION="${{ github.event.release.tag_name || inputs.image_tag }}"
-          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push for ${{ matrix.archs.arch }}
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          target: runner
-          platforms: linux/${{ matrix.archs.arch }}
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/fastgpt-plugin:${{ steps.version.outputs.value }}-${{ matrix.archs.arch }}
-            ghcr.io/${{ github.repository_owner }}/fastgpt-plugin:${{ github.sha }}-${{ matrix.archs.arch }}
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.description=FastGPT Plugin release image
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ steps.version.outputs.value }}
-          cache-from: type=gha,scope=release-image-${{ matrix.archs.arch }}
-          cache-to: type=gha,mode=max,scope=release-image-${{ matrix.archs.arch }}
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.archs.arch }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-image:
-    name: Publish multi-arch image
-    runs-on: ubuntu-24.04
-    needs:
-      - build-image
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_NAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Login to Ali Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: registry.cn-hangzhou.aliyuncs.com
           username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
@@ -123,23 +69,216 @@ jobs:
 
       - name: Resolve image version
         id: version
+        env:
+          IMAGE_VERSION: ${{ github.event.release.tag_name || inputs.image_tag }}
         run: |
-          VERSION="${{ github.event.release.tag_name || inputs.image_tag }}"
-          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [[ -z "$IMAGE_VERSION" || ! "$IMAGE_VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+            echo "::error::Image tag must match [A-Za-z0-9][A-Za-z0-9._-]{0,127}."
+            exit 1
+          fi
+          echo "value=${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
+      - name: Build and push to GitHub Container Registry for ${{ matrix.archs.arch }}
+        id: build-ghcr
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runner
+          platforms: linux/${{ matrix.archs.arch }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository_owner }}/fastgpt-plugin",push-by-digest=true,push=true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=FastGPT Plugin release image
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.value }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build and push to Ali Hub for ${{ matrix.archs.arch }}
+        id: build-aliyun
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile
+          target: runner
+          platforms: linux/${{ matrix.archs.arch }}
+          provenance: false
+          sbom: false
+          outputs: type=image,"name=${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-plugin",push-by-digest=true,push=true
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=FastGPT Plugin release image
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.value }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+
+      - name: Export digests
         run: |
-          GITHUB_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-plugin"
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests/ghcr" "${{ runner.temp }}/digests/aliyun"
+          ghcr_digest="${{ steps.build-ghcr.outputs.digest }}"
+          aliyun_digest="${{ steps.build-aliyun.outputs.digest }}"
+          [[ "$ghcr_digest" == sha256:* ]] || { echo "::error::Missing GHCR image digest"; exit 1; }
+          [[ "$aliyun_digest" == sha256:* ]] || { echo "::error::Missing Ali Hub image digest"; exit 1; }
+          touch "${{ runner.temp }}/digests/ghcr/${ghcr_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/aliyun/${aliyun_digest#sha256:}"
+
+      - name: Upload GHCR digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ghcr-digests-${{ github.sha }}-${{ matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Ali Hub digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: aliyun-digests-${{ github.sha }}-${{ matrix.archs.arch }}
+          path: ${{ runner.temp }}/digests/aliyun/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-image:
+    name: Publish multi-arch image
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-24.04
+    needs:
+      - build-image
+    timeout-minutes: 120
+
+    steps:
+      - name: Download GHCR digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: /tmp/digests
+          pattern: ghcr-digests-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Download Ali Hub digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: /tmp/digests/aliyun
+          pattern: aliyun-digests-${{ github.sha }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_NAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Login to Ali Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: registry.cn-hangzhou.aliyuncs.com
+          username: ${{ secrets.FASTGPT_ALI_IMAGE_USER }}
+          password: ${{ secrets.FASTGPT_ALI_IMAGE_PSW }}
+
+      - name: Resolve image version
+        id: version
+        env:
+          IMAGE_VERSION: ${{ github.event.release.tag_name || inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$IMAGE_VERSION" || ! "$IMAGE_VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+            echo "::error::Image tag must match [A-Za-z0-9][A-Za-z0-9._-]{0,127}."
+            exit 1
+          fi
+          echo "value=${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest lists and push
+        working-directory: /tmp/digests
+        timeout-minutes: 120
+        run: |
+          set -euo pipefail
+
+          GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/fastgpt-plugin"
           ALI_IMAGE="${{ secrets.FASTGPT_ALI_IMAGE_PREFIX }}/fastgpt-plugin"
           DOCKER_IMAGE="${{ secrets.DOCKER_IMAGE_NAME }}/fastgpt-plugin"
+          VERSION="$IMAGE_VERSION"
 
-          VERSION="${{ steps.version.outputs.value }}"
-          TAGS="$GITHUB_IMAGE:$VERSION $GITHUB_IMAGE:latest $GITHUB_IMAGE:${{ github.sha }} $ALI_IMAGE:$VERSION $ALI_IMAGE:latest $ALI_IMAGE:${{ github.sha }} $DOCKER_IMAGE:$VERSION $DOCKER_IMAGE:latest $DOCKER_IMAGE:${{ github.sha }}"
-
-          for TAG in $TAGS; do
-            echo "Creating manifest list for: $TAG"
-            docker buildx imagetools create -t "$TAG" \
-              $(printf 'ghcr.io/${{ github.repository_owner }}/fastgpt-plugin@sha256:%s ' *)
-            sleep 2
+          GHCR_SOURCES=()
+          for digest_file in ./*; do
+            [[ -f "$digest_file" ]] || continue
+            GHCR_SOURCES+=("${GHCR_IMAGE}@sha256:$(basename "$digest_file")")
           done
+
+          ALI_SOURCES=()
+          for digest_file in aliyun/*; do
+            [[ -f "$digest_file" ]] || continue
+            ALI_SOURCES+=("${ALI_IMAGE}@sha256:$(basename "$digest_file")")
+          done
+
+          if [[ "${#GHCR_SOURCES[@]}" -ne 2 || "${#ALI_SOURCES[@]}" -ne 2 ]]; then
+            echo "::error::Expected exactly two GHCR and two Ali Hub digests."
+            exit 1
+          fi
+
+          retry_imagetools_create() {
+            local tag="$1"
+            shift
+
+            for attempt in 1 2 3 4; do
+              if docker buildx imagetools create -t "$tag" "$@"; then
+                return 0
+              fi
+
+              if [[ "$attempt" -eq 4 ]]; then
+                echo "::error::Failed to push manifest ${tag} after 3 retries."
+                return 1
+              fi
+
+              echo "::warning::Failed to push manifest ${tag}; retrying in $((attempt * 15)) seconds (${attempt}/3)."
+              sleep $((attempt * 15))
+            done
+          }
+
+          for TAG in \
+            "${GHCR_IMAGE}:${VERSION}" \
+            "${GHCR_IMAGE}:latest" \
+            "${GHCR_IMAGE}:${{ github.sha }}" \
+            "${DOCKER_IMAGE}:${VERSION}" \
+            "${DOCKER_IMAGE}:latest" \
+            "${DOCKER_IMAGE}:${{ github.sha }}"; do
+            retry_imagetools_create "$TAG" "${GHCR_SOURCES[@]}"
+            sleep 5
+          done
+
+          for TAG in \
+            "${ALI_IMAGE}:${VERSION}" \
+            "${ALI_IMAGE}:latest" \
+            "${ALI_IMAGE}:${{ github.sha }}"; do
+            retry_imagetools_create "$TAG" "${ALI_SOURCES[@]}"
+            sleep 5
+          done
+
+          verify_manifest() {
+            local tag="$1"
+            local manifest
+            manifest="$(docker buildx imagetools inspect --raw "$tag")"
+            jq -e '
+              ([.manifests[]?.platform | select(.os == "linux" and .architecture == "amd64")] | length == 1) and
+              ([.manifests[]?.platform | select(.os == "linux" and .architecture == "arm64")] | length == 1) and
+              ([.manifests[]?.platform | select(.os == "linux" and (.architecture != "amd64" and .architecture != "arm64"))] | length == 0)
+            ' <<<"$manifest" >/dev/null
+          }
+
+          verify_manifest "${GHCR_IMAGE}:${VERSION}"
+          verify_manifest "${ALI_IMAGE}:${VERSION}"
+        env:
+          IMAGE_VERSION: ${{ steps.version.outputs.value }}


### PR DESCRIPTION
## Summary

- Align plugin preview, release, and connection gateway image workflows with the recent FastGPT CI improvements.
- Build the server preview image for every opened, synchronized, or reopened PR, with stale runs canceled and a lightweight Docker artifact.
- Build amd64 and arm64 images by digest, publish registry-specific manifests to GHCR, Ali Hub, and Docker Hub, and verify the final manifests.
- Harden privileged preview publishing with exact PR-head checks, collaborator permission checks, manual `/preview push` support, and immutable action references.

## Why

The previous workflows could publish from stale preview builds, depended on mutable action tags, and assembled Ali Hub manifests from GHCR digests. The new flow keeps untrusted PR builds read-only, separates registry digests, retries transient manifest publication failures, and validates the resulting platforms.

## Validation

- `pnpm test` — 43 files and 266 tests passed.
- YAML parsing, shell syntax, action SHA pin, preview artifact contract, and manifest guard checks passed.
- Prettier and `git diff --check` passed.
