### PR TITLE
chore: update model provider presets

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts
@@ -18,6 +18,19 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'glm-5.3',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 900000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object'],
+      vision: false,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'glm-5.1',
       maxContext: 200000,
       maxTokens: 128000,

--- a/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
@@ -32,6 +32,19 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'gemini-3.7-flash',
+      maxContext: 1048576,
+      maxTokens: 65536,
+      quoteMaxToken: 1000000,
+      vision: true,
+      audio: true,
+      video: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gemini-3.1-pro-preview-customtools',
       maxContext: 1000000,
       maxTokens: 64000,


### PR DESCRIPTION
## Summary

- Add ChatGLM `glm-5.3` with 1M context and 128K output limits.
- Add Gemini `gemini-3.7-flash` with 1,048,576 input and 65,536 output limits.
- Audit all 34 registered providers against official catalogs; add-only policy applied and no presets removed.

## Official references

- Google: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash
- Zhipu AI: https://docs.bigmodel.cn/cn/guide/start/model-overview

## Scope decisions

Skipped preview/experimental models, specialized audio/image/video/realtime models, routers/aggregators, third-party-hosted models, and parameter-scale open checkpoints. ai360 did not have complete primary model metadata for a safe preset, and Moka/Other have no registered presets to audit.

## Verification

- Inventory: 34 providers, 299 presets
- Duplicate model IDs: none
- `bun run test`: 43 files, 266 tests passed
- Targeted ESLint: passed
- `git diff --check`: passed
- `bun tsc --noEmit`: existing unrelated error at `sdk/factory/src/tool-factory.test.ts:285`