### PR TITLE
fix(security): resolve CodeQL code-scanning alerts

### DIFF
--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -125,7 +125,8 @@ export class CreateCommand extends BaseCommand {
   }
 
   private pickDebugRunInputJson(type: CreatePluginCommandOptions['type']): string {
-    return this.pickDebugRunInput(type).replace(/"/g, '\\"');
+    const input = JSON.stringify(this.pickDebugRunInput(type));
+    return input.slice(1, -1);
   }
 
   private pickDebugRunToolOption(type: CreatePluginCommandOptions['type']): string {

--- a/packages/infrastructure/src/file-storage/local-file-storage.repo.test.ts
+++ b/packages/infrastructure/src/file-storage/local-file-storage.repo.test.ts
@@ -42,6 +42,14 @@ describe('LocalFileStorageRepo permissions', () => {
       await expectMode(path.dirname(path.join(basePath, fileKey)), 0o700);
       await expectMode(path.join(basePath, fileKey), 0o600);
       await expectMode(`${path.join(basePath, fileKey)}.meta.json`, 0o600);
+
+      await rm(`${path.join(basePath, fileKey)}.meta.json`);
+      const [legacyMeta, legacyError] = await repo.getInfo(fileKey);
+      expect(legacyError).toBeNull();
+      expect(legacyMeta).toMatchObject({
+        fileKey,
+        size: Buffer.byteLength('export default {}')
+      });
     } finally {
       process.umask(previousUmask);
     }

--- a/packages/infrastructure/src/file-storage/local-file-storage.repo.ts
+++ b/packages/infrastructure/src/file-storage/local-file-storage.repo.ts
@@ -308,28 +308,35 @@ export class LocalFileStorageRepo implements LocalFileStoragePort {
     const absolutePath = this.resolveStoragePath(fileKey);
 
     try {
-      const stats = await stat(absolutePath);
-      const persistedMeta = await this.readPersistedMeta(absolutePath);
-      const normalizedFileKey = this.normalizeFileKey(fileKey);
-      const buffer = persistedMeta ? null : await readFile(absolutePath);
-      const fallbackContentType = buffer
-        ? detectMimeTypeFromContent(
-            buffer,
-            getMimeTypeFromFilename(path.basename(normalizedFileKey)) ?? 'application/octet-stream'
-          )
-        : undefined;
+      const fileHandle = await open(absolutePath, 'r');
+      try {
+        const stats = await fileHandle.stat();
+        const persistedMeta = await this.readPersistedMeta(absolutePath);
+        const normalizedFileKey = this.normalizeFileKey(fileKey);
+        const buffer = persistedMeta ? null : await fileHandle.readFile();
+        const fallbackContentType = buffer
+          ? detectMimeTypeFromContent(
+              buffer,
+              getMimeTypeFromFilename(path.basename(normalizedFileKey)) ??
+                'application/octet-stream'
+            )
+          : undefined;
 
-      const metaData = FileMetaSchema.parse({
-        fileKey: normalizedFileKey,
-        fileName: persistedMeta?.fileName ?? path.basename(normalizedFileKey),
-        contentType:
-          persistedMeta?.contentType ?? fallbackContentType ?? 'application/octet-stream',
-        size: stats.size,
-        etag: persistedMeta?.etag ?? calculateMD5(buffer ?? Buffer.alloc(0)),
-        createTime: persistedMeta?.createTime ? new Date(persistedMeta.createTime) : stats.birthtime
-      });
+        const metaData = FileMetaSchema.parse({
+          fileKey: normalizedFileKey,
+          fileName: persistedMeta?.fileName ?? path.basename(normalizedFileKey),
+          contentType:
+            persistedMeta?.contentType ?? fallbackContentType ?? 'application/octet-stream',
+          size: stats.size,
+          etag: persistedMeta?.etag ?? calculateMD5(buffer ?? Buffer.alloc(0)),
+          createTime:
+            persistedMeta?.createTime ? new Date(persistedMeta.createTime) : stats.birthtime
+        });
 
-      return successResult(metaData);
+        return successResult(metaData);
+      } finally {
+        await fileHandle.close();
+      }
     } catch (error) {
       return failureResult(
         {


### PR DESCRIPTION
## Summary
- Use JSON serialization when embedding generated debug input so backslashes and quotes are escaped correctly.
- Read local file metadata and legacy file contents through one open file handle to avoid a stat/read TOCTOU race.
- Add regression coverage for legacy files without persisted metadata.

## Verification
- CLI create tests: 6 passed
- Local file storage test: 1 passed
- `corepack pnpm typecheck` passed
- Targeted ESLint passed
- `git diff --check` passed

## CodeQL
Addresses alerts #54 and #39.