### PR TITLE
build: auto-build SDK factory after install

### DIFF
--- a/dev.md
+++ b/dev.md
@@ -10,6 +10,8 @@ Language: [简体中文](./dev_zh_CN.md) | [English](./dev.md)
 pnpm install
 ```
 
+The install hook builds `sdk/factory` so plugins started during development can resolve `dist/index.js`. Run `pnpm build:sdk-factory` again after changing the SDK source.
+
 ### Build
 
 ```bash

--- a/dev_zh_CN.md
+++ b/dev_zh_CN.md
@@ -10,6 +10,8 @@
 pnpm install
 ```
 
+安装完成后会自动构建 `sdk/factory`，确保开发环境启动插件时可以解析 `dist/index.js`。修改 SDK 源码后可重新运行 `pnpm build:sdk-factory`。
+
 ### 构建
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "vitest run",
     "prepare": "node scripts/prepare-husky.mjs",
+    "postinstall": "pnpm build:sdk-factory",
     "lint": "eslint --fix",
     "typecheck": "tsc --noEmit",
     "build:pkg": "pnpm tsc && pnpm --filter modules/tool build",


### PR DESCRIPTION
## Summary

- build `sdk/factory` automatically from the workspace `postinstall` hook
- document the development startup requirement and SDK rebuild command
- preserve the server production bundle copy of the SDK factory dist

## Verification

- `pnpm run postinstall`
- `pnpm build:server`
- `pnpm exec tsc --noEmit`
- `pnpm test` (44 files, 299 tests)
