### PR TITLE
fix(i18n): require zh-CN in plugin metadata

### DIFF
--- a/packages/domain/src/value-objects/error.vo.test.ts
+++ b/packages/domain/src/value-objects/error.vo.test.ts
@@ -5,6 +5,7 @@ import {
   createReasonError,
   deserializeError,
   getErrorDefinition,
+  getErrorReason,
   RegisteredError,
   registerErrors,
   serializeError,
@@ -42,6 +43,13 @@ if (!getErrorDefinition(ErrorCode.pluginRuntimeConfigLoadFailed)) {
 }
 
 describe('RegisteredError', () => {
+  it('does not treat English-only objects as i18n reasons', () => {
+    expect(getErrorReason({ en: 'English only' })).toEqual({
+      en: 'Internal Server Error',
+      'zh-CN': '服务器内部错误'
+    });
+  });
+
   it('preserves registered metadata and native cause', () => {
     const cause = new Error('database offline');
     const error = createError(ErrorCode.pluginRuntimeConfigLoadFailed, { cause });

--- a/packages/domain/src/value-objects/error.vo.ts
+++ b/packages/domain/src/value-objects/error.vo.ts
@@ -381,7 +381,7 @@ function isI18nString(value: unknown): value is I18nStringType {
   return (
     isRecord(value) &&
     typeof value.en === 'string' &&
-    (value['zh-CN'] === undefined || typeof value['zh-CN'] === 'string') &&
+    typeof value['zh-CN'] === 'string' &&
     (value['zh-Hant'] === undefined || typeof value['zh-Hant'] === 'string')
   );
 }

--- a/packages/domain/src/value-objects/i18n-string.vo.test.ts
+++ b/packages/domain/src/value-objects/i18n-string.vo.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { I18nStringSchema } from './i18n-string.vo';
+
+describe('I18nStringSchema', () => {
+  it('requires Simplified Chinese translations', () => {
+    expect(() => I18nStringSchema.parse({ en: 'English' })).toThrow();
+  });
+
+  it('accepts English and Simplified Chinese translations without Korean', () => {
+    expect(
+      I18nStringSchema.parse({
+        en: 'English',
+        'zh-CN': '简体中文'
+      })
+    ).toEqual({
+      en: 'English',
+      'zh-CN': '简体中文'
+    });
+  });
+});

--- a/packages/domain/src/value-objects/i18n-string.vo.ts
+++ b/packages/domain/src/value-objects/i18n-string.vo.ts
@@ -8,7 +8,7 @@ export type I18nLangType = z.infer<typeof I18nLangSchema>;
 
 export const I18nStringSchema = z.object({
   [I18nLangEnum.en]: z.string(),
-  [I18nLangEnum['zh-CN']]: z.string().optional(),
+  [I18nLangEnum['zh-CN']]: z.string(),
   [I18nLangEnum['zh-Hant']]: z.string().optional()
 });
 

--- a/packages/infrastructure/src/plugin/utils/pkg-parser.test.ts
+++ b/packages/infrastructure/src/plugin/utils/pkg-parser.test.ts
@@ -8,11 +8,13 @@ const baseManifest = {
   version: '1.0.0',
   type: 'tool',
   name: {
-    en: 'Etag demo'
+    en: 'Etag demo',
+    'zh-CN': 'Etag 示例'
   },
   icon: 'logo.svg',
   description: {
-    en: 'Etag demo'
+    en: 'Etag demo',
+    'zh-CN': 'Etag 示例'
   },
   toolDescription: 'Etag demo',
   secretSchema: {}

--- a/sdk/client/package.json
+++ b/sdk/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastgpt-plugin/sdk-client",
-  "version": "0.1.0-alpha.5",
+  "version": "1.1.0",
   "description": "TypeScript client SDK for calling the FastGPT Plugin service APIs.",
   "keywords": [
     "fastgpt",

--- a/sdk/factory/package.json
+++ b/sdk/factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastgpt-plugin/sdk-factory",
-  "version": "0.1.0-alpha.1",
+  "version": "1.1.0",
   "description": "TypeScript factory SDK for authoring FastGPT Plugin tools and tool suites.",
   "keywords": [
     "fastgpt",


### PR DESCRIPTION
## Summary
- require `zh-CN` in plugin i18n metadata schemas and runtime error reasons
- add regression coverage and update manifest fixtures
- align `@fastgpt-plugin/sdk-client` and `@fastgpt-plugin/sdk-factory` versions to `1.1.0`

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm test` (45 files, 302 tests passed)
- SDK client and factory builds passed