### PR TITLE
chore: refresh model provider source links

### DIFF
--- a/.codex/skills/model-provider-updater/references/provider_sources.json
+++ b/.codex/skills/model-provider-updater/references/provider_sources.json
@@ -4,7 +4,7 @@
     "notes": "Use official OpenAI model docs or authenticated model-list API if credentials are explicitly available."
   },
   "Claude": {
-    "docs": ["https://platform.claude.com/docs/en/about-claude/models/overview"],
+    "docs": ["https://platform.claude.com/docs/en/models/overview"],
     "notes": "Anthropic documents current model IDs and aliases on the models page."
   },
   "Gemini": {
@@ -20,15 +20,15 @@
     "notes": "Use Mistral model overview and API docs."
   },
   "Qwen": {
-    "docs": ["https://help.aliyun.com/zh/model-studio/getting-started/models"],
+    "docs": ["https://help.aliyun.com/zh/model-studio/models"],
     "notes": "Use Alibaba Cloud Model Studio model docs."
   },
   "Doubao": {
-    "docs": ["https://www.volcengine.com/docs/82379/1330310"],
+    "docs": ["https://www.volcengine.com/docs/82379/2549861?lang=zh"],
     "notes": "Use Volcengine Ark/Doubao model docs."
   },
   "DeepSeek": {
-    "docs": ["https://api-docs.deepseek.com/quick_start/pricing"],
+    "docs": ["https://api-docs.deepseek.com/quick_start/pricing/"],
     "notes": "Use DeepSeek API docs and pricing/model page."
   },
   "ChatGLM": {
@@ -36,7 +36,7 @@
     "notes": "Use Zhipu BigModel model docs."
   },
   "MiniMax": {
-    "docs": ["https://platform.minimaxi.com/document/Models"],
+    "docs": ["https://platform.minimaxi.com/docs/api-reference/models/openai/list-models"],
     "notes": "Use MiniMax platform model docs."
   },
   "Moonshot": {
@@ -44,7 +44,7 @@
     "notes": "Use Kimi/Moonshot official API docs, models page, or authenticated list-models API."
   },
   "Ernie": {
-    "docs": ["https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Fm2vrveyu"],
+    "docs": ["https://cloud.baidu.com/doc/qianfan/s/Kmh4stnjp"],
     "notes": "Use Baidu Qianfan/Wenxin model docs."
   },
   "SparkDesk": {
@@ -52,7 +52,7 @@
     "notes": "Use iFlytek Spark official docs."
   },
   "Hunyuan": {
-    "docs": ["https://cloud.tencent.com/document/product/1823/132252"],
+    "docs": ["https://cloud.tencent.com/document/product/1823/130051"],
     "notes": "Use Tencent TokenHub's official Hy model docs."
   },
   "Baichuan": {
@@ -116,7 +116,7 @@
     "notes": "Use InternLM official docs."
   },
   "AliCloud": {
-    "docs": ["https://help.aliyun.com/zh/model-studio/getting-started/models"],
+    "docs": ["https://help.aliyun.com/zh/model-studio/models"],
     "notes": "Use Alibaba Cloud official model docs."
   },
   "PPIO": {
@@ -124,7 +124,7 @@
     "notes": "Use PPIO official docs; verify the exact model page during each run."
   },
   "AntLing": {
-    "docs": ["https://developer.ant-ling.com/zh-CN/docs", "https://www.ant-ling.com/en/"],
+    "docs": ["https://developer.ant-ling.com/en/docs/models", "https://www.ant-ling.com/en/"],
     "notes": "Use Ant Ling developer docs and official model-family pages."
   },
   "Moka": {


### PR DESCRIPTION
## Summary

- Verified the existing branch is based on the latest `upstream/main` (`833fd36`) on 2026-08-26; merging `upstream/main` was a no-op.
- Audited all 34 registered static model providers against their official catalogs under the add-only policy.
- Found no new in-scope primary chat/reasoning model IDs to add; the inventory remains 307 presets with 307 unique IDs.
- Kept this PR's existing source-reference refresh as the only code delta. The generated plan contains no additions and no removals.

## Audit result (2026-08-26)

- 32 providers were checked against official catalogs; `Moka` and `Other` remain pending because they do not have authoritative source hints.
- Source health: 35 configured URLs checked; 34 returned HTTP 200, while SparkDesk returned an access-limited HTTP 403.
- Excluded deprecated, preview/experimental, specialized, realtime/audio/image/video, parameter-scale/open-weight, third-party-hosted, and coding-plan-only entries according to the updater policy.
- Representative catalogs reviewed: OpenAI, Gemini, xAI, Mistral, Qwen, DeepSeek, Baidu Qianfan, Tencent TokenHub, Kimi, Groq, Ant Ling, Baichuan, StepFun, Yi, and Doubao.

## Validation

- `inventory`: 34 providers, 307 presets, 307 unique IDs, no duplicates
- `apply-plan --dry-run`: 0 additions, 0 removals, 0 provider changes
- `apply-plan --write`: 0 additions, 0 removals, 0 provider changes
- `bun run test`: 45 files passed, 303 tests passed
- `git diff --check`: passed
- `bun tsc --noEmit`: still blocked by four pre-existing missing `zh-CN` fixture fields in `packages/infrastructure/src/plugin/tool.impl.test.ts` (lines 22, 26, 156, and 157); this PR does not modify that file
