### PR TITLE
feat: add glm-5.3-flash model preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/ChatGLM/index.ts
@@ -5,7 +5,21 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
-      model: 'glm-5.2',
+      model: 'glm-5.3-flash',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 900000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object'],
+      vision: true,
+      video: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'glm-5.3',
       maxContext: 1000000,
       maxTokens: 128000,
       quoteMaxToken: 900000,
@@ -18,7 +32,7 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'glm-5.3',
+      model: 'glm-5.2',
       maxContext: 1000000,
       maxTokens: 128000,
       quoteMaxToken: 900000,

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -6,11 +6,12 @@ import {
   ModelTypeEnum
 } from '@domain/entities/model.entity';
 
+import chatglm from './ChatGLM';
 import doubao from './Doubao';
 import gemini from './Gemini';
 import qwen from './Qwen';
 
-const staticModelList = [gemini, qwen, doubao].flatMap((provider) =>
+const staticModelList = [chatglm, doubao, gemini, qwen].flatMap((provider) =>
   provider.list.map((model) =>
     ModelItemSchema.parse({
       ...model,
@@ -79,5 +80,18 @@ describe('static model multimodal capabilities', () => {
       video: true
     });
     expect(getModel('Doubao', 'doubao-seed-2-0-pro-260215')).not.toHaveProperty('audio');
+  });
+
+  it('marks GLM-5.3-Flash with its multimodal and agent capabilities', () => {
+    expect(getModel('ChatGLM', 'glm-5.3-flash')).toMatchObject({
+      maxContext: 1000000,
+      maxTokens: 128000,
+      responseFormatList: ['text', 'json_object'],
+      vision: true,
+      video: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    });
   });
 });


### PR DESCRIPTION
## Summary

- add the official `glm-5.3-flash` ChatGLM preset
- configure 1M context, 128K output, image/video input, reasoning, structured output, and tool calling
- add regression coverage for the published multimodal and agent capabilities

## Audit

Audited all 34 registered providers again on 2026-08-30 using the strict add-only model-provider workflow. The executable plan records 32 checked providers and Moka/Other pending because they have no authoritative catalog hints. No additional in-scope general LLM/chat/reasoning model was confirmed, all provider files were unchanged, and every removal list is empty.

The open PR branch contains latest `upstream/main` (`a523809`) through merge commit `c69ab76`; the merge-base was re-verified before this audit.

Official evidence:
- https://docs.bigmodel.cn/cn/guide/start/model-overview
- https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5.3-flash
- https://developers.openai.com/api/docs/models
- https://platform.claude.com/docs/en/models/overview
- https://ai.google.dev/gemini-api/docs/models
- https://ai.google.dev/gemini-api/docs/changelog
- https://docs.x.ai/developers/models
- https://docs.mistral.ai/models
- https://help.aliyun.com/zh/model-studio/models
- https://api-docs.deepseek.com/quick_start/pricing/
- https://cloud.baidu.com/doc/qianfan/s/Kmh4stnjp
- https://cloud.tencent.com/document/product/1823/130051
- https://console.groq.com/docs/models

Newly surfaced candidates were classified conservatively. OpenAI Cyber remains access-restricted and specialized; Gemini Omni Flash and Gemini 3.5 Transcribe are video/transcription models; Mistral Shieldstral is moderation-focused; MiniMax H3 is video generation; and Groq's Qwen 3.8 27B listing is a preview parameter-scale checkpoint. Those are out of scope for this general model refresh. GLM-5.3-Flash and Qwen3.8-Flash are already represented in the branch.

## Validation

- inventory: 34 providers, 309 presets, 309 unique IDs, no duplicates
- source hints: 34 HTTP 200; SparkDesk access-limited HTTP 403; Moka/Other have no hints
- plan dry-run/write: 32 checked, 2 pending, 0 additions, 0 removals, 0 file changes
- targeted tests for the model change: 2 files, 39 tests passed
- full tests after main sync: 46 files, 342 tests passed
- `git diff --check` passed
- `bun tsc --noEmit` reports only four pre-existing missing `zh-CN` fields in `packages/infrastructure/src/plugin/tool.impl.test.ts`
