### PR TITLE
fix(doubao): drop two unversioned model ids that 404

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Doubao/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Doubao/index.ts
@@ -49,32 +49,6 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'doubao-seed-2.1-pro',
-      maxContext: 256000,
-      maxTokens: 256000,
-      quoteMaxToken: 256000,
-      maxTemperature: 1,
-      vision: true,
-      video: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'doubao-seed-2.1-turbo',
-      maxContext: 256000,
-      maxTokens: 256000,
-      quoteMaxToken: 256000,
-      maxTemperature: 1,
-      vision: true,
-      video: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
       model: 'doubao-seed-2-0-pro-260215',
       maxContext: 256000,
       maxTokens: 128000,


### PR DESCRIPTION
## The bug

`provider/Doubao/index.ts` lists `doubao-seed-2.1-pro` and
`doubao-seed-2.1-turbo` next to `doubao-seed-2-1-pro-260628` and
`doubao-seed-2-1-turbo-260628`. The dot-form ids aren't accepted by Ark:

```
doubao-seed-2.1-pro          -> 404 InvalidEndpointOrModel.NotFound
doubao-seed-2.1-turbo        -> 404 InvalidEndpointOrModel.NotFound
doubao-seed-2-1-pro-260628   -> 200
doubao-seed-2-1-turbo-260628 -> 200
```

Ark requires the fully versioned model id. The one exception is
`doubao-seed-evolving`, which this file already has right.

These ids reach the API unchanged — `createChatCompletion.ts` does
`body.model = modelData.model` — so anyone who picks one of the two gets a 404
rather than a working model.

Their remaining fields are byte-identical to the versioned entries beside them
(same `maxContext`, `maxTokens`, `vision`, `video`, `reasoning`,
`reasoningEffort`, `toolChoice`), so they look like accidental duplicates rather
than deliberate aliases. If they *were* meant as short aliases, they'd need a
resolution step that doesn't currently exist — happy to go that way instead if
you'd prefer.

## Verification

After removing them I tested every remaining entry against
`ark.cn-beijing.volces.com` with a real key:

| Type | Count | Result |
| --- | --- | --- |
| `llm` | 9 | all HTTP 200 |
| `embedding` | 2 | all HTTP 200 |

So the file has no dead ids left. Diff is `0+/26-` — deletions only, nothing else
touched.
