### PR TITLE
feat: add Claude Fable 5.1 model preset

### DIFF
--- a/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Claude/index.ts
@@ -5,6 +5,18 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'claude-fable-5-1',
+      maxContext: 1000000,
+      maxTokens: 128000,
+      quoteMaxToken: 200000,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      showTopP: false
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'claude-fable-5',
       maxContext: 1000000,
       maxTokens: 128000,

--- a/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
@@ -43,4 +43,19 @@ describe('static model provider ordering', () => {
     expect(lastQwen38Index).toBeGreaterThanOrEqual(0);
     expect(firstQwen37Index).toBeGreaterThan(lastQwen38Index);
   });
+
+  it('places ChatGLM 5.3 models before 5.2 and 5.1 models', () => {
+    const chatglm = providerConfigs.find(({ provider }) => provider === 'ChatGLM');
+    const modelIds = chatglm?.list.map((model) => model.model) ?? [];
+    const lastGlm53Index = modelIds.reduce(
+      (lastIndex, model, index) => (model.startsWith('glm-5.3') ? index : lastIndex),
+      -1
+    );
+    const glm52Index = modelIds.indexOf('glm-5.2');
+    const glm51Index = modelIds.indexOf('glm-5.1');
+
+    expect(lastGlm53Index).toBeGreaterThanOrEqual(0);
+    expect(glm52Index).toBeGreaterThan(lastGlm53Index);
+    expect(glm51Index).toBeGreaterThan(glm52Index);
+  });
 });


### PR DESCRIPTION
## Summary

- audit all 34 registered model providers against their current official catalogs using the add-only model-provider workflow
- add Anthropic Claude Fable 5.1 (`claude-fable-5-1`) as a confirmed in-scope primary reasoning model
- preserve the add-only policy with no preset removals as of 2026-09-02
- retain regression coverage requiring ChatGLM 5.3 models to remain ahead of 5.2 and 5.1

## 2026-09-02 audit

- continued the existing unmerged PR branch; latest `upstream/main` (`b1d08df`) remains the direct branch base
- 32 providers checked; Moka and Other remain pending because neither has an authoritative catalog source
- 35 configured source hints checked: 34 returned HTTP 200 and SparkDesk was access-limited at HTTP 403; Moka and Other have no hints
- inventory: 308 presets / 308 unique model IDs
- executable plan dry-run/write: 1 addition (`claude-fable-5-1`), 0 removals; every `remove` array is empty
- Anthropic's official model overview lists Claude Fable 5.1 as active, released 2026-09-01, with 1M context, 128K output, vision, adaptive always-on reasoning, and tool use
- other current official catalogs reconfirmed all in-scope general models already represented locally; newly surfaced image/video/audio, realtime, preview, dated, specialized coding, alias-only, and parameter-scale/checkpoint IDs remain excluded by policy
- official sources reviewed included OpenAI Models, Claude model overview, Gemini models, Alibaba Model Studio, Zhipu model overview, DeepSeek pricing/model docs, MiniMax models, Kimi model list, xAI models, Mistral models, Baidu Qianfan, Tencent TokenHub, Ant Ling model docs, Groq supported models, and the remaining provider-specific official source hints

## Validation

- `bun run test` (46 files, 343 tests passed)
- provider ordering test (36 tests passed in the existing branch)
- inventory uniqueness passed (308 presets / 308 unique IDs)
- `git diff --check` passed
- `bun tsc --noEmit` reports only four pre-existing missing `zh-CN` fixture fields in `packages/infrastructure/src/plugin/tool.impl.test.ts` (lines 22, 26, 156, 157)
