### PR TITLE
feat: add Spark X2 and Gemini 3.8 Flash presets

### DIFF
--- a/.codex/skills/model-provider-updater/SKILL.md
+++ b/.codex/skills/model-provider-updater/SKILL.md
@@ -16,6 +16,22 @@ This workflow is strictly additive. Never remove an existing provider preset, ev
 
 Every executable update plan must keep each provider's `remove` array empty. The helper script retains removal support for legacy or explicitly separate workflows, but this skill must not populate or apply removal operations.
 
+## Complete-Audit Invariant
+
+A repository-wide refresh is complete only when every provider currently registered by `packages/infrastructure/src/static-data/models/index.ts` appears exactly once in the plan and has a non-pending audit result. Never infer coverage from the number of changed files: providers with no additions must still be recorded as checked.
+
+`apply-plan` enforces this invariant by default and rejects missing providers, duplicate aliases, or `auditStatus: "pending"`. Use `--allow-partial` only when the user explicitly scopes the request to named providers; never use it to make an incomplete full refresh pass.
+
+Coverage alone is not sufficient. Each provider audit must also preserve a verifiable catalog diff:
+
+- Check every URL prefilled from `references/provider_sources.json`; add newly discovered official catalog, release-note, deprecation, or pricing URLs when they are needed to establish the current state.
+- Record every exact, in-scope primary model ID found in official sources in `candidateModelIds`, including candidates that will be deliberately skipped.
+- Compare `candidateModelIds` with the local inventory. Every candidate missing locally must appear in exactly one of `add` or `skip`; every `skip` entry requires a concrete reason.
+- Record `checkedAt` as the current run date. Stale plans are rejected and must be re-audited rather than replayed.
+- Set `catalogStatus` to `reviewed` when an official in-scope catalog was enumerated. Use `no-in-scope-models`, `dynamic-catalog`, or `no-authoritative-catalog` only when that is the actual result, and explain it in `auditNote`.
+
+This candidate ledger is the completion proof. A reachable page, a search snippet, or an `auditStatus` marker by itself is never proof that the catalog was scanned.
+
 ## Workflow
 
 1. Inventory the current registry.
@@ -26,27 +42,31 @@ Every executable update plan must keep each provider's `remove` array empty. The
 
    Use `--json` when another script or a temporary comparison file needs structured output.
 
-2. Check providers one by one against official sources.
+2. Check every registered provider one by one against official sources.
 
-   Start from `references/provider_sources.json`, but verify the current official page/API during the run because model catalogs change often. Use official provider docs, official pricing/model pages, or official model-list APIs. Do not use third-party blogs, search snippets, or aggregator pages as removal evidence unless the provider is that aggregator, such as OpenRouter.
+   Start from every URL listed for that provider in `references/provider_sources.json`, but verify the current official page/API during the run because model catalogs change often. When a provider publishes both a catalog and release notes/changelog, inspect both: catalog pages can lag a just-released model. Use official provider docs, official pricing/model pages, release notes, deprecation pages, or official model-list APIs. Do not use third-party blogs, search snippets, or aggregator pages as evidence unless the provider is that aggregator, such as OpenRouter.
 
    `check-sources` only checks whether source-hint URLs are reachable enough to use as starting points. A 403 access-limited result can still be acceptable for docs that block automated requests, and a passing source check is not evidence that the provider catalog was audited.
 
-3. Classify differences conservatively.
+3. Build the candidate ledger and classify every difference conservatively.
 
    For a general model refresh, add only primary LLM/chat/reasoning models. Do not add derived or specialized non-LLM variants just because the provider docs list them, such as TTS, STT, transcription, audio, image, video, realtime, moderation, or batch-only model IDs (`gpt-4o-transcribe`, `gpt-4o-mini-tts`, and similar). Also skip open-weight/checkpoint style IDs that encode parameter scale or architecture details when the provider has productized main model IDs, such as Qwen `qwen3.6-27b`, `qwen3.5-397b-a17b`, `qwen3.5-122b-a10b`, or `qwen3.5-35b-a3b`; prefer `max`, `plus`, `flash`, or other documented main product model IDs instead. Handle those only when the user explicitly asks for that modality/model class or when the provider itself is a modality-specific or open-model provider already maintained for that type.
 
-   Add a preset when an official source lists an in-scope model that is absent locally and it belongs to an existing provider. Clone the closest existing preset in the same provider and family, then adjust context, output limit, vision, reasoning, tool calling, response-format, and field-map fields from official docs or the closest local pattern.
+   Transcribe exact official model IDs into `candidateModelIds`; do not rely on prose such as "latest models checked." Compare that list mechanically with the local inventory. Add a preset when an official source lists an in-scope model that is absent locally and it belongs to an existing provider. Clone the closest existing preset in the same provider and family, then adjust context, output limit, vision, reasoning, tool calling, response-format, and field-map fields from official docs or the closest local pattern.
+
+   If a missing candidate is intentionally excluded by the scope rules, put it in `skip` with its exact model ID and a specific reason. The plan is incomplete while any missing candidate is neither added nor skipped.
 
    Keep every existing preset. Deprecated, retired, unavailable, superseded, preview, experimental, and dated candidate IDs may be noted in the audit summary, but must not be removed by this workflow.
 
 4. Create and apply an update plan.
 
-   Generate a template and fill only confirmed additions. Keep every `remove` array empty:
+   For a full refresh, generate the all-provider template without `--provider`, then fill the audit evidence and confirmed additions. Keep every `remove` array empty:
 
    ```bash
-   node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs plan-template --provider OpenAI > /tmp/model-provider-plan.json
+   node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs plan-template > /tmp/model-provider-plan.json
    ```
+
+   For an explicitly scoped request, `plan-template --provider OpenAI` and `apply-plan --allow-partial` are allowed. The template pre-populates the configured official `sources`; do not delete an unvisited source to bypass checking it.
 
    Dry-run before writing:
 
@@ -58,11 +78,12 @@ Every executable update plan must keep each provider's `remove` array empty. The
    The plan format is documented in `references/plan.example.json`. That file includes an intentionally unregistered `ExampleProvider` shape example, so use `plan-template` for executable plans instead of applying the example file directly. Keep every audited provider in the plan:
    - Use `auditStatus: "checked"` with empty `add` and `remove` when the provider was checked and no registry change is needed.
    - Use `auditStatus: "changed"` when adding presets.
-   - Leave `auditStatus: "pending"` only for providers not yet checked.
+   - `auditStatus: "pending"` is template state only and cannot be applied.
+   - Fill `catalogStatus`, `auditNote`, `candidateModelIds`, and `skip` for every provider, even when nothing changes.
 
    `replace` supports top-level provider-model fields only, such as `maxContext`, `maxTokens`, `vision`, `reasoning`, `responseFormatList`, or `fieldMap`. Do not use dotted paths such as `fieldMap.max_tokens`; replace the full top-level object instead.
 
-   The script only edits providers registered by `packages/infrastructure/src/static-data/models/index.ts`, skips already-present additions, validates the whole plan before writing any file, and errors if `cloneFrom` or required evidence fields are missing. Although the script can mechanically process removals for legacy workflows, this skill must always submit empty `remove` arrays.
+   The script only edits providers registered by `packages/infrastructure/src/static-data/models/index.ts`, validates the whole plan before writing any file, and errors on incomplete provider coverage, unchecked configured sources, pending states, missing audit notes, duplicate IDs, unaccounted catalog candidates, or missing addition evidence. Although the script can mechanically process removals for legacy workflows, this skill must always submit empty `remove` arrays.
 
 5. Validate.
 
@@ -75,7 +96,9 @@ Every executable update plan must keep each provider's `remove` array empty. The
 
 ## Evidence Rules
 
-- Record the official source URL and check date in the plan for every provider audited, including providers with no changes.
+- Record every official source URL checked, the check date, catalog status, exact candidate model IDs, and an audit note for every provider, including providers with no changes.
+- Do not mark a provider checked until all configured source URLs have been inspected and every missing candidate has an `add` or reasoned `skip` disposition.
+- Treat model catalogs and release notes as complementary evidence. If they conflict because a release is newer than the catalog page, use the newer official release/model page and record the discrepancy in `auditNote`.
 - Do not add removal entries to the plan. Record retirement or deprecation findings only in the run summary when they materially affect users.
 - Prefer primary API references over marketing pages when fields disagree.
 - When official docs group many modality-specific variants under one family, treat the main public chat/LLM model as the preset target and skip derivative IDs unless the request names that capability.
@@ -90,7 +113,7 @@ Every executable update plan must keep each provider's `remove` array empty. The
 
 - `inventory`: list registered providers, provider files, model counts, and type counts.
 - `plan-template`: create a JSON update plan skeleton for all or selected providers.
-- `apply-plan`: mechanically apply cloned additions. Its legacy removal capability is out of scope for this skill.
+- `apply-plan`: validate complete provider/source/candidate coverage and mechanically apply cloned additions. Its legacy removal capability is out of scope for this skill.
 - `check-sources`: sanity-check source hint URLs from `references/provider_sources.json`.
 
 Use the script for repeatable mechanics, then review the diff manually before final validation.

--- a/.codex/skills/model-provider-updater/SKILL.md
+++ b/.codex/skills/model-provider-updater/SKILL.md
@@ -52,7 +52,7 @@ This candidate ledger is the completion proof. A reachable page, a search snippe
 
    For a general model refresh, add only primary LLM/chat/reasoning models. Do not add derived or specialized non-LLM variants just because the provider docs list them, such as TTS, STT, transcription, audio, image, video, realtime, moderation, or batch-only model IDs (`gpt-4o-transcribe`, `gpt-4o-mini-tts`, and similar). Also skip open-weight/checkpoint style IDs that encode parameter scale or architecture details when the provider has productized main model IDs, such as Qwen `qwen3.6-27b`, `qwen3.5-397b-a17b`, `qwen3.5-122b-a10b`, or `qwen3.5-35b-a3b`; prefer `max`, `plus`, `flash`, or other documented main product model IDs instead. Handle those only when the user explicitly asks for that modality/model class or when the provider itself is a modality-specific or open-model provider already maintained for that type.
 
-   Transcribe exact official model IDs into `candidateModelIds`; do not rely on prose such as "latest models checked." Compare that list mechanically with the local inventory. Add a preset when an official source lists an in-scope model that is absent locally and it belongs to an existing provider. Clone the closest existing preset in the same provider and family, then adjust context, output limit, vision, reasoning, tool calling, response-format, and field-map fields from official docs or the closest local pattern.
+   Transcribe exact official model IDs into `candidateModelIds`; do not rely on prose such as "latest models checked." Compare that list mechanically with the local inventory. Add a preset when an official source lists an in-scope model that is absent locally and it belongs to an existing provider. Clone the closest existing preset in the same provider and family, then adjust context, output limit, vision, reasoning, tool calling, response-format, and field-map fields from official docs or the closest local pattern. When the new model is newer or more capable than its clone source, set `insertBefore` to the existing model that it must precede; cloning and display placement are separate decisions.
 
    If a missing candidate is intentionally excluded by the scope rules, put it in `skip` with its exact model ID and a specific reason. The plan is incomplete while any missing candidate is neither added nor skipped.
 
@@ -82,6 +82,8 @@ This candidate ledger is the completion proof. A reachable page, a search snippe
    - Fill `catalogStatus`, `auditNote`, `candidateModelIds`, and `skip` for every provider, even when nothing changes.
 
    `replace` supports top-level provider-model fields only, such as `maxContext`, `maxTokens`, `vision`, `reasoning`, `responseFormatList`, or `fieldMap`. Do not use dotted paths such as `fieldMap.max_tokens`; replace the full top-level object instead.
+
+   `insertBefore` accepts an exact existing model ID and places the cloned addition before it. Use it to preserve newest-or-most-capable-first ordering; otherwise additions are inserted after `cloneFrom` for backward compatibility.
 
    The script only edits providers registered by `packages/infrastructure/src/static-data/models/index.ts`, validates the whole plan before writing any file, and errors on incomplete provider coverage, unchecked configured sources, pending states, missing audit notes, duplicate IDs, unaccounted catalog candidates, or missing addition evidence. Although the script can mechanically process removals for legacy workflows, this skill must always submit empty `remove` arrays.
 

--- a/.codex/skills/model-provider-updater/references/plan.example.json
+++ b/.codex/skills/model-provider-updater/references/plan.example.json
@@ -28,6 +28,7 @@
         {
           "model": "example-new-model",
           "cloneFrom": "example-existing-model",
+          "insertBefore": "example-existing-model",
           "reason": "Official model catalog lists this as a new public model.",
           "replace": {
             "maxContext": 128000,

--- a/.codex/skills/model-provider-updater/references/plan.example.json
+++ b/.codex/skills/model-provider-updater/references/plan.example.json
@@ -1,16 +1,29 @@
 {
   "providers": {
     "OpenAI": {
-      "source": "https://platform.openai.com/docs/models",
+      "sources": ["https://developers.openai.com/api/docs/models"],
       "checkedAt": "2026-05-04",
       "auditStatus": "checked",
+      "catalogStatus": "reviewed",
+      "auditNote": "Enumerated the official primary model IDs and reconciled them with the local inventory.",
+      "candidateModelIds": ["gpt-5.4"],
+      "skip": [],
       "add": [],
       "remove": []
     },
     "ExampleProvider": {
-      "source": "https://example.invalid/official-model-catalog",
+      "sources": ["https://example.invalid/official-model-catalog"],
       "checkedAt": "2026-05-04",
       "auditStatus": "changed",
+      "catalogStatus": "reviewed",
+      "auditNote": "Enumerated the official catalog; one primary model is new and one specialized model is intentionally excluded.",
+      "candidateModelIds": ["example-new-model", "example-specialized-audio"],
+      "skip": [
+        {
+          "model": "example-specialized-audio",
+          "reason": "Audio-only model is outside the general LLM refresh scope."
+        }
+      ],
       "add": [
         {
           "model": "example-new-model",

--- a/.codex/skills/model-provider-updater/references/provider_sources.json
+++ b/.codex/skills/model-provider-updater/references/provider_sources.json
@@ -8,8 +8,13 @@
     "notes": "Anthropic documents current model IDs and aliases on the models page."
   },
   "Gemini": {
-    "docs": ["https://ai.google.dev/gemini-api/docs/models"],
-    "notes": "Use Gemini API model docs or official list models API."
+    "docs": [
+      "https://ai.google.dev/gemini-api/docs/models",
+      "https://ai.google.dev/gemini-api/docs/changelog",
+      "https://ai.google.dev/gemini-api/docs/deprecations",
+      "https://ai.google.dev/gemini-api/docs/pricing"
+    ],
+    "notes": "Check the model catalog, release notes, deprecations, and pricing together because the catalog page can lag a newly released model. Use the official list-models API too when credentials are explicitly available."
   },
   "Grok": {
     "docs": ["https://docs.x.ai/developers/models"],

--- a/.codex/skills/model-provider-updater/scripts/model_provider_presets.mjs
+++ b/.codex/skills/model-provider-updater/scripts/model_provider_presets.mjs
@@ -169,6 +169,7 @@ async function commandApplyPlan(parsedArgs) {
         action: 'add',
         model: addition.model,
         cloneFrom: addition.cloneFrom,
+        insertBefore: addition.insertBefore,
         status: result.status,
         reason: addition.reason
       });
@@ -522,6 +523,12 @@ function addModelEntry(content, addition) {
   if (!source) {
     throw new Error(`cloneFrom model not found: ${addition.cloneFrom}`);
   }
+  const insertionTarget = addition.insertBefore
+    ? entries.find((entry) => entry.model === addition.insertBefore)
+    : undefined;
+  if (addition.insertBefore && !insertionTarget) {
+    throw new Error(`insertBefore model not found: ${addition.insertBefore}`);
+  }
 
   let cloneText = source.text.replace(
     /(model:\s*)(['"`])([^'"`]+)(['"`])/,
@@ -531,6 +538,15 @@ function addModelEntry(content, addition) {
     for (const [key, value] of Object.entries(addition.replace)) {
       cloneText = replaceSimpleProperty(cloneText, key, value);
     }
+  }
+
+  if (insertionTarget) {
+    const lineStart = content.lastIndexOf('\n', insertionTarget.start) + 1;
+    const indent = content.slice(lineStart, insertionTarget.start);
+    return {
+      content: `${content.slice(0, lineStart)}${indent}${cloneText},\n${content.slice(lineStart)}`,
+      status: 'added'
+    };
   }
 
   const lineStart = content.lastIndexOf('\n', source.start) + 1;
@@ -754,6 +770,9 @@ function validateAddition(providerName, addition, index) {
   }
   if (!isNonEmptyString(addition.reason)) {
     throw new Error(`${providerName}: add[${index}] is missing reason`);
+  }
+  if (addition.insertBefore !== undefined && !isNonEmptyString(addition.insertBefore)) {
+    throw new Error(`${providerName}: add[${index}].insertBefore must be a non-empty model ID`);
   }
   if (addition.replace !== undefined && !isPlainObject(addition.replace)) {
     throw new Error(`${providerName}: add[${index}].replace must be an object`);

--- a/.codex/skills/model-provider-updater/scripts/model_provider_presets.mjs
+++ b/.codex/skills/model-provider-updater/scripts/model_provider_presets.mjs
@@ -109,14 +109,20 @@ function commandInventory(parsedArgs) {
 function commandPlanTemplate(parsedArgs) {
   const repoRoot = getRepoRoot(parsedArgs);
   const providers = filterProviders(getRegisteredProviders(repoRoot), parsedArgs.provider);
+  const sourceHints = getSourceHints();
   const plan = { providers: {} };
   for (const provider of providers) {
     const content = readFileSync(provider.filePath, 'utf8');
     const declaredProvider = readDeclaredProvider(content) || provider.dirName;
+    const hint = sourceHints[declaredProvider] || sourceHints[provider.dirName] || {};
     plan.providers[declaredProvider] = {
-      source: '',
+      sources: Array.isArray(hint.docs) ? hint.docs : [],
       checkedAt: todayDateString(),
       auditStatus: 'pending',
+      catalogStatus: 'pending',
+      auditNote: '',
+      candidateModelIds: [],
+      skip: [],
       add: [],
       remove: []
     };
@@ -141,13 +147,18 @@ async function commandApplyPlan(parsedArgs) {
     throw new Error('Plan must contain an object at providers');
   }
   const registeredProviders = getRegisteredProviders(repoRoot);
+  const sourceHints = getSourceHints();
+  const allowPartial = Boolean(parsedArgs['allow-partial']);
+  const resolvedPlans = resolveAndValidatePlanCoverage(repoRoot, providerPlans, registeredProviders, allowPartial);
   const results = [];
   const pendingWrites = [];
 
-  for (const [providerName, providerPlan] of Object.entries(providerPlans)) {
-    const providerFile = resolveProviderFile(repoRoot, providerName, registeredProviders);
-    const validatedPlan = validateProviderPlan(providerFile.provider, providerPlan);
+  for (const { providerFile, providerPlan } of resolvedPlans) {
     let content = readFileSync(providerFile.filePath, 'utf8');
+    const localModelIds = new Set(readModelEntries(content).map((entry) => entry.model));
+    const hint = sourceHints[providerFile.provider] || sourceHints[providerFile.dirName] || {};
+    const expectedSources = Array.isArray(hint.docs) ? hint.docs : [];
+    const validatedPlan = validateProviderPlan(providerFile.provider, providerPlan, localModelIds, expectedSources);
     const before = content;
     const providerResults = [];
 
@@ -181,9 +192,13 @@ async function commandApplyPlan(parsedArgs) {
       provider: providerFile.provider,
       file: relative(repoRoot, providerFile.filePath),
       changed,
-      source: validatedPlan.source,
+      sources: validatedPlan.sources,
       checkedAt: validatedPlan.checkedAt,
       auditStatus: validatedPlan.auditStatus,
+      catalogStatus: validatedPlan.catalogStatus,
+      auditNote: validatedPlan.auditNote,
+      candidateModelIds: validatedPlan.candidateModelIds,
+      skippedCandidates: validatedPlan.skip,
       operations: providerResults
     });
   }
@@ -201,7 +216,9 @@ async function commandApplyPlan(parsedArgs) {
     return;
   }
 
-  console.log(`apply-plan ${write ? 'write' : 'dry-run'} complete`);
+  console.log(
+    `apply-plan ${write ? 'write' : 'dry-run'} complete (${results.length}/${registeredProviders.length} providers audited${allowPartial ? ', partial mode' : ''})`
+  );
   for (const result of results) {
     console.log(`- ${result.provider} (${result.file}): ${result.changed ? 'changed' : 'unchanged'}`);
     for (const operation of result.operations) {
@@ -214,8 +231,7 @@ async function commandApplyPlan(parsedArgs) {
 async function commandCheckSources(parsedArgs) {
   const repoRoot = getRepoRoot(parsedArgs);
   const providers = filterProviders(getRegisteredProviders(repoRoot), parsedArgs.provider);
-  const sourcePath = join(skillDir, 'references/provider_sources.json');
-  const sourceHints = JSON.parse(readFileSync(sourcePath, 'utf8'));
+  const sourceHints = getSourceHints();
   const results = [];
   const tasks = [];
   const concurrency = parsePositiveInteger(parsedArgs.concurrency, 4);
@@ -226,7 +242,12 @@ async function commandCheckSources(parsedArgs) {
     const hint = sourceHints[providerName] || sourceHints[provider.dirName] || {};
     const docs = Array.isArray(hint.docs) ? hint.docs : [];
     if (docs.length === 0) {
-      results.push({ provider: providerName, url: '', ok: false, status: 'missing-source-hint' });
+      results.push({
+        provider: providerName,
+        url: '',
+        ok: false,
+        status: 'missing-source-hint'
+      });
       continue;
     }
     for (const url of docs) {
@@ -238,7 +259,11 @@ async function commandCheckSources(parsedArgs) {
     if (!parsedArgs.json) {
       console.error(`[${index + 1}/${tasks.length}] checking ${task.provider}: ${task.url}`);
     }
-    return { provider: task.provider, url: task.url, ...(await checkUrl(task.url)) };
+    return {
+      provider: task.provider,
+      url: task.url,
+      ...(await checkUrl(task.url))
+    };
   });
   results.push(...checked);
 
@@ -282,7 +307,10 @@ async function checkUrl(url) {
     }
     return { ok: response.ok, status: String(response.status) };
   } catch (error) {
-    return { ok: false, status: error instanceof Error ? error.message : String(error) };
+    return {
+      ok: false,
+      status: error instanceof Error ? error.message : String(error)
+    };
   }
 }
 
@@ -304,7 +332,12 @@ function getRegisteredProviders(repoRoot) {
 
 function filterProviders(providers, providerFilter) {
   if (!providerFilter) return providers;
-  const requested = new Set(String(providerFilter).split(',').map((item) => item.trim()).filter(Boolean));
+  const requested = new Set(
+    String(providerFilter)
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  );
   return providers.filter((provider) => {
     const content = readFileSync(provider.filePath, 'utf8');
     const declaredProvider = readDeclaredProvider(content) || provider.dirName;
@@ -318,13 +351,54 @@ function resolveProviderFile(repoRoot, providerName, registeredProviders = getRe
     const content = readFileSync(filePath, 'utf8');
     const declaredProvider = readDeclaredProvider(content) || provider.dirName;
     if (provider.dirName === providerName || declaredProvider === providerName) {
-      return { provider: declaredProvider, dirName: provider.dirName, filePath };
+      return {
+        provider: declaredProvider,
+        dirName: provider.dirName,
+        filePath
+      };
     }
   }
 
   throw new Error(
     `Provider is not registered in packages/infrastructure/src/static-data/models/index.ts: ${providerName}`
   );
+}
+
+function getSourceHints() {
+  const sourcePath = join(skillDir, 'references/provider_sources.json');
+  return JSON.parse(readFileSync(sourcePath, 'utf8'));
+}
+
+function resolveAndValidatePlanCoverage(repoRoot, providerPlans, registeredProviders, allowPartial) {
+  const resolved = [];
+  const seenProviders = new Set();
+
+  for (const [providerName, providerPlan] of Object.entries(providerPlans)) {
+    const providerFile = resolveProviderFile(repoRoot, providerName, registeredProviders);
+    if (seenProviders.has(providerFile.provider)) {
+      throw new Error(
+        `Plan contains the same registered provider more than once through aliases: ${providerFile.provider}`
+      );
+    }
+    seenProviders.add(providerFile.provider);
+    resolved.push({ providerFile, providerPlan });
+  }
+
+  if (!allowPartial) {
+    const missing = registeredProviders
+      .map((provider) => {
+        const content = readFileSync(provider.filePath, 'utf8');
+        return readDeclaredProvider(content) || provider.dirName;
+      })
+      .filter((providerName) => !seenProviders.has(providerName));
+    if (missing.length > 0) {
+      throw new Error(
+        `Complete audit required: ${missing.length} registered provider(s) missing from plan: ${missing.join(', ')}. Use --allow-partial only for an explicitly scoped provider request.`
+      );
+    }
+  }
+
+  return resolved;
 }
 
 function readDeclaredProvider(content) {
@@ -433,7 +507,10 @@ function removeModelEntry(content, model) {
     if (content[cursor] === ',') removeStart = cursor;
   }
 
-  return { content: content.slice(0, removeStart) + content.slice(removeEnd), removed: true };
+  return {
+    content: content.slice(0, removeStart) + content.slice(removeEnd),
+    removed: true
+  };
 }
 
 function addModelEntry(content, addition) {
@@ -509,25 +586,52 @@ function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function validateProviderPlan(providerName, providerPlan) {
+function validateProviderPlan(providerName, providerPlan, localModelIds, expectedSources) {
   if (!isPlainObject(providerPlan)) {
     throw new Error(`${providerName}: provider plan must be an object`);
   }
   const add = providerPlan.add === undefined ? [] : providerPlan.add;
   const remove = providerPlan.remove === undefined ? [] : providerPlan.remove;
+  const skip = providerPlan.skip === undefined ? [] : providerPlan.skip;
+  const sources = providerPlan.sources;
+  const candidateModelIds = providerPlan.candidateModelIds;
   if (!Array.isArray(add)) {
     throw new Error(`${providerName}: add must be an array`);
   }
   if (!Array.isArray(remove)) {
     throw new Error(`${providerName}: remove must be an array`);
   }
+  if (!Array.isArray(skip)) {
+    throw new Error(`${providerName}: skip must be an array`);
+  }
+  if (!Array.isArray(sources)) {
+    throw new Error(`${providerName}: sources must be an array of every official URL checked`);
+  }
+  if (!Array.isArray(candidateModelIds)) {
+    throw new Error(`${providerName}: candidateModelIds must be an array`);
+  }
 
   const hasChanges = add.length > 0 || remove.length > 0;
   const auditStatus = String(providerPlan.auditStatus || (hasChanges ? 'changed' : 'pending'));
-  const source = typeof providerPlan.source === 'string' ? providerPlan.source.trim() : '';
+  const catalogStatus = String(providerPlan.catalogStatus || 'pending');
+  const auditNote = typeof providerPlan.auditNote === 'string' ? providerPlan.auditNote.trim() : '';
   const checkedAt = typeof providerPlan.checkedAt === 'string' ? providerPlan.checkedAt.trim() : '';
+  const validatedSources = validateUniqueStrings(providerName, 'sources', sources);
+  const validatedCandidateModelIds = validateUniqueStrings(providerName, 'candidateModelIds', candidateModelIds);
+  const validatedAdd = add.map((addition, index) => validateAddition(providerName, addition, index));
+  const validatedRemove = remove.map((removal, index) => validateRemoval(providerName, removal, index));
+  const validatedSkip = skip.map((item, index) => validateSkip(providerName, item, index));
+
   if (!['pending', 'checked', 'changed'].includes(auditStatus)) {
     throw new Error(`${providerName}: auditStatus must be pending, checked, or changed`);
+  }
+  if (auditStatus === 'pending') {
+    throw new Error(`${providerName}: auditStatus is pending; every provider must be checked before apply-plan`);
+  }
+  if (!['reviewed', 'no-in-scope-models', 'dynamic-catalog', 'no-authoritative-catalog'].includes(catalogStatus)) {
+    throw new Error(
+      `${providerName}: catalogStatus must be reviewed, no-in-scope-models, dynamic-catalog, or no-authoritative-catalog`
+    );
   }
   if (hasChanges && auditStatus !== 'changed') {
     throw new Error(`${providerName}: auditStatus must be changed when add or remove is non-empty`);
@@ -535,20 +639,107 @@ function validateProviderPlan(providerName, providerPlan) {
   if (!hasChanges && auditStatus === 'changed') {
     throw new Error(`${providerName}: auditStatus changed requires a non-empty add or remove list`);
   }
-  if ((hasChanges || auditStatus === 'checked') && !source) {
-    throw new Error(`${providerName}: source is required for changed or checked providers`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(checkedAt)) {
+    throw new Error(`${providerName}: checkedAt must use YYYY-MM-DD`);
   }
-  if ((hasChanges || auditStatus === 'checked') && !/^\d{4}-\d{2}-\d{2}$/.test(checkedAt)) {
-    throw new Error(`${providerName}: checkedAt must use YYYY-MM-DD for changed or checked providers`);
+  if (checkedAt !== todayDateString()) {
+    throw new Error(
+      `${providerName}: checkedAt must be today's date (${todayDateString()}); regenerate or re-audit stale plans`
+    );
+  }
+  if (!auditNote) {
+    throw new Error(`${providerName}: auditNote is required to record what was checked and concluded`);
+  }
+  const missingConfiguredSources = expectedSources.filter(
+    (expectedSource) => !validatedSources.includes(expectedSource)
+  );
+  if (missingConfiguredSources.length > 0) {
+    throw new Error(
+      `${providerName}: configured official source(s) were not checked: ${missingConfiguredSources.join(', ')}`
+    );
+  }
+  if (catalogStatus === 'reviewed' && validatedSources.length === 0) {
+    throw new Error(`${providerName}: reviewed catalog requires at least one official source`);
+  }
+  if (catalogStatus === 'reviewed' && validatedCandidateModelIds.length === 0) {
+    throw new Error(`${providerName}: reviewed catalog requires non-empty candidateModelIds`);
+  }
+  if (catalogStatus === 'no-in-scope-models' && validatedSources.length === 0) {
+    throw new Error(`${providerName}: no-in-scope-models requires at least one official source`);
+  }
+  if (catalogStatus !== 'reviewed' && validatedCandidateModelIds.length > 0) {
+    throw new Error(`${providerName}: candidateModelIds must be empty unless catalogStatus is reviewed`);
+  }
+
+  const candidateSet = new Set(validatedCandidateModelIds);
+  const addModels = validateUniqueModels(providerName, 'add', validatedAdd);
+  const skipModels = validateUniqueModels(providerName, 'skip', validatedSkip);
+  validateUniqueModels(providerName, 'remove', validatedRemove);
+
+  for (const model of addModels) {
+    if (skipModels.has(model)) {
+      throw new Error(`${providerName}: candidate cannot appear in both add and skip: ${model}`);
+    }
+  }
+
+  for (const addition of validatedAdd) {
+    if (!candidateSet.has(addition.model)) {
+      throw new Error(`${providerName}: added model is absent from candidateModelIds: ${addition.model}`);
+    }
+    if (localModelIds.has(addition.model)) {
+      throw new Error(`${providerName}: add contains a model already present locally: ${addition.model}`);
+    }
+  }
+  for (const skipped of validatedSkip) {
+    if (!candidateSet.has(skipped.model)) {
+      throw new Error(`${providerName}: skipped model is absent from candidateModelIds: ${skipped.model}`);
+    }
+    if (localModelIds.has(skipped.model)) {
+      throw new Error(`${providerName}: skip contains a model already present locally: ${skipped.model}`);
+    }
+  }
+  for (const candidate of validatedCandidateModelIds) {
+    if (!localModelIds.has(candidate) && !addModels.has(candidate) && !skipModels.has(candidate)) {
+      throw new Error(
+        `${providerName}: unaccounted catalog candidate ${candidate}; add it or include it in skip with a reason`
+      );
+    }
   }
 
   return {
-    source,
+    sources: validatedSources,
     checkedAt,
     auditStatus,
-    add: add.map((addition, index) => validateAddition(providerName, addition, index)),
-    remove: remove.map((removal, index) => validateRemoval(providerName, removal, index))
+    catalogStatus,
+    auditNote,
+    candidateModelIds: validatedCandidateModelIds,
+    skip: validatedSkip,
+    add: validatedAdd,
+    remove: validatedRemove
   };
+}
+
+function validateUniqueStrings(providerName, fieldName, values) {
+  const normalized = values.map((value, index) => {
+    if (!isNonEmptyString(value)) {
+      throw new Error(`${providerName}: ${fieldName}[${index}] must be a non-empty string`);
+    }
+    return value.trim();
+  });
+  const duplicate = normalized.find((value, index) => normalized.indexOf(value) !== index);
+  if (duplicate) {
+    throw new Error(`${providerName}: ${fieldName} contains duplicate value: ${duplicate}`);
+  }
+  return normalized;
+}
+
+function validateUniqueModels(providerName, fieldName, entries) {
+  const models = entries.map((entry) => entry.model);
+  const duplicate = models.find((model, index) => models.indexOf(model) !== index);
+  if (duplicate) {
+    throw new Error(`${providerName}: ${fieldName} contains duplicate model: ${duplicate}`);
+  }
+  return new Set(models);
 }
 
 function validateAddition(providerName, addition, index) {
@@ -589,6 +780,19 @@ function validateRemoval(providerName, removal, index) {
     throw new Error(`${providerName}: remove[${index}] is missing reason`);
   }
   return removal;
+}
+
+function validateSkip(providerName, skipped, index) {
+  if (!isPlainObject(skipped)) {
+    throw new Error(`${providerName}: skip[${index}] must be an object`);
+  }
+  if (!isNonEmptyString(skipped.model)) {
+    throw new Error(`${providerName}: skip[${index}] is missing model`);
+  }
+  if (!isNonEmptyString(skipped.reason)) {
+    throw new Error(`${providerName}: skip[${index}] is missing reason`);
+  }
+  return skipped;
 }
 
 function findTopLevelProperty(objectText, key) {
@@ -848,12 +1052,13 @@ function printUsage() {
   console.log(`Usage:
   node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs inventory [--provider OpenAI] [--json]
   node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs plan-template [--provider OpenAI]
-  node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/plan.json (--dry-run | --write) [--json]
+  node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /tmp/plan.json (--dry-run | --write) [--allow-partial] [--json]
   node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs check-sources [--provider OpenAI] [--strict] [--json] [--concurrency 4]
 
 Options:
   --repo-root <path>  Override the FastGPT plugin repository root.
   --provider <name>   Limit to one provider or a comma-separated list.
+  --allow-partial     Permit a scoped plan that omits registered providers; never use for a full refresh.
   --concurrency <n>   Limit concurrent source URL checks.
 `);
 }

--- a/.codex/skills/model-provider-updater/scripts/model_provider_presets.test.mjs
+++ b/.codex/skills/model-provider-updater/scripts/model_provider_presets.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { after, test } from 'node:test';
@@ -154,4 +154,38 @@ test('a candidate cannot be both added and skipped', () => {
   const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /cannot appear in both add and skip/);
+});
+
+test('insertBefore separates clone source from display placement', () => {
+  const repoRoot = join(tempDir, 'placement-repo');
+  const providerDir = join(repoRoot, 'packages/infrastructure/src/static-data/models/provider/Gemini');
+  mkdirSync(providerDir, { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'packages/infrastructure/src/static-data/models/index.ts'),
+    "import gemini from './provider/Gemini';\n\nexport default [gemini];\n"
+  );
+  writeFileSync(
+    join(providerDir, 'index.ts'),
+    "const models = { provider: 'Gemini', list: [\n  { model: 'gemini-3.7-flash', maxTokens: 65536 }\n] };\nexport default models;\n"
+  );
+  const plan = writePlan(
+    'insert-before',
+    geminiPlan({
+      auditStatus: 'changed',
+      candidateModelIds: ['gemini-3.7-flash', 'gemini-future-test-model'],
+      add: [
+        {
+          model: 'gemini-future-test-model',
+          cloneFrom: 'gemini-3.7-flash',
+          insertBefore: 'gemini-3.7-flash',
+          reason: 'Synthetic newer model for placement testing.'
+        }
+      ]
+    })
+  );
+
+  const result = run(['apply-plan', '--repo-root', repoRoot, '--plan', plan, '--write']);
+  assert.equal(result.status, 0, result.stderr);
+  const providerFile = readFileSync(join(providerDir, 'index.ts'), 'utf8');
+  assert.ok(providerFile.indexOf('gemini-future-test-model') < providerFile.indexOf('gemini-3.7-flash'));
 });

--- a/.codex/skills/model-provider-updater/scripts/model_provider_presets.test.mjs
+++ b/.codex/skills/model-provider-updater/scripts/model_provider_presets.test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'model_provider_presets.mjs');
+const tempDir = mkdtempSync(join(tmpdir(), 'model-provider-presets-test-'));
+const today = localDateString();
+
+after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+function run(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: 'utf8'
+  });
+}
+
+function localDateString(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function writePlan(name, providerPlan) {
+  const path = join(tempDir, `${name}.json`);
+  writeFileSync(path, JSON.stringify({ providers: { Gemini: providerPlan } }, null, 2));
+  return path;
+}
+
+function geminiPlan(overrides = {}) {
+  return {
+    sources: [
+      'https://ai.google.dev/gemini-api/docs/models',
+      'https://ai.google.dev/gemini-api/docs/changelog',
+      'https://ai.google.dev/gemini-api/docs/deprecations',
+      'https://ai.google.dev/gemini-api/docs/pricing'
+    ],
+    checkedAt: today,
+    auditStatus: 'checked',
+    catalogStatus: 'reviewed',
+    auditNote: 'Checked every configured official source and reconciled exact primary model IDs.',
+    candidateModelIds: ['gemini-3.7-flash'],
+    skip: [],
+    add: [],
+    remove: [],
+    ...overrides
+  };
+}
+
+test('complete audits reject a plan that omits registered providers', () => {
+  const plan = writePlan('partial', geminiPlan());
+  const result = run(['apply-plan', '--plan', plan, '--dry-run']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Complete audit required/);
+});
+
+test('an all-provider plan can prove complete registry coverage', () => {
+  const templateResult = run(['plan-template']);
+  assert.equal(templateResult.status, 0, templateResult.stderr);
+  const inventoryResult = run(['inventory', '--json']);
+  assert.equal(inventoryResult.status, 0, inventoryResult.stderr);
+
+  const plan = JSON.parse(templateResult.stdout);
+  const inventory = JSON.parse(inventoryResult.stdout);
+  for (const provider of inventory.providers) {
+    const providerPlan = plan.providers[provider.provider];
+    providerPlan.auditStatus = 'checked';
+    providerPlan.auditNote = 'Test audit reconciled every exact candidate with the local inventory.';
+    if (provider.modelIds.length > 0) {
+      providerPlan.catalogStatus = 'reviewed';
+      providerPlan.candidateModelIds = provider.modelIds;
+    } else if (providerPlan.sources.length > 0) {
+      providerPlan.catalogStatus = 'no-in-scope-models';
+    } else {
+      providerPlan.catalogStatus = 'no-authoritative-catalog';
+    }
+  }
+
+  const planPath = join(tempDir, 'complete.json');
+  writeFileSync(planPath, JSON.stringify(plan, null, 2));
+  const result = run(['apply-plan', '--plan', planPath, '--dry-run']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /34\/34 providers audited/);
+});
+
+test('explicit partial audits accept fully evidenced checked providers', () => {
+  const plan = writePlan('valid-partial', geminiPlan());
+  const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /1\/34 providers audited, partial mode/);
+});
+
+test('pending providers cannot be marked complete by apply-plan', () => {
+  const plan = writePlan('pending', geminiPlan({ auditStatus: 'pending' }));
+  const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /auditStatus is pending/);
+});
+
+test('every configured official source must be checked', () => {
+  const plan = writePlan('missing-source', geminiPlan({ sources: ['https://ai.google.dev/gemini-api/docs/models'] }));
+  const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /configured official source\(s\) were not checked/);
+});
+
+test('a missing catalog candidate must be added or explicitly skipped', () => {
+  const plan = writePlan(
+    'unaccounted-candidate',
+    geminiPlan({ candidateModelIds: ['gemini-3.7-flash', 'gemini-3.8-flash'] })
+  );
+  const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unaccounted catalog candidate gemini-3\.8-flash/);
+});
+
+test('a reasoned skip closes the catalog diff', () => {
+  const plan = writePlan(
+    'skipped-candidate',
+    geminiPlan({
+      candidateModelIds: ['gemini-3.7-flash', 'gemini-3.8-flash'],
+      skip: [
+        {
+          model: 'gemini-3.8-flash',
+          reason: 'Explicit test-only scope exclusion.'
+        }
+      ]
+    })
+  );
+  const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('a candidate cannot be both added and skipped', () => {
+  const plan = writePlan(
+    'conflicting-disposition',
+    geminiPlan({
+      auditStatus: 'changed',
+      candidateModelIds: ['gemini-3.7-flash', 'gemini-3.8-flash'],
+      add: [
+        {
+          model: 'gemini-3.8-flash',
+          cloneFrom: 'gemini-3.7-flash',
+          reason: 'Official release.'
+        }
+      ],
+      skip: [{ model: 'gemini-3.8-flash', reason: 'Conflicting test disposition.' }]
+    })
+  );
+  const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /cannot appear in both add and skip/);
+});

--- a/.codex/skills/model-provider-updater/scripts/model_provider_presets.test.mjs
+++ b/.codex/skills/model-provider-updater/scripts/model_provider_presets.test.mjs
@@ -111,21 +111,21 @@ test('every configured official source must be checked', () => {
 test('a missing catalog candidate must be added or explicitly skipped', () => {
   const plan = writePlan(
     'unaccounted-candidate',
-    geminiPlan({ candidateModelIds: ['gemini-3.7-flash', 'gemini-3.8-flash'] })
+    geminiPlan({ candidateModelIds: ['gemini-3.7-flash', 'gemini-future-test-model'] })
   );
   const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /unaccounted catalog candidate gemini-3\.8-flash/);
+  assert.match(result.stderr, /unaccounted catalog candidate gemini-future-test-model/);
 });
 
 test('a reasoned skip closes the catalog diff', () => {
   const plan = writePlan(
     'skipped-candidate',
     geminiPlan({
-      candidateModelIds: ['gemini-3.7-flash', 'gemini-3.8-flash'],
+      candidateModelIds: ['gemini-3.7-flash', 'gemini-future-test-model'],
       skip: [
         {
-          model: 'gemini-3.8-flash',
+          model: 'gemini-future-test-model',
           reason: 'Explicit test-only scope exclusion.'
         }
       ]
@@ -140,15 +140,15 @@ test('a candidate cannot be both added and skipped', () => {
     'conflicting-disposition',
     geminiPlan({
       auditStatus: 'changed',
-      candidateModelIds: ['gemini-3.7-flash', 'gemini-3.8-flash'],
+      candidateModelIds: ['gemini-3.7-flash', 'gemini-future-test-model'],
       add: [
         {
-          model: 'gemini-3.8-flash',
+          model: 'gemini-future-test-model',
           cloneFrom: 'gemini-3.7-flash',
           reason: 'Official release.'
         }
       ],
-      skip: [{ model: 'gemini-3.8-flash', reason: 'Conflicting test disposition.' }]
+      skip: [{ model: 'gemini-future-test-model', reason: 'Conflicting test disposition.' }]
     })
   );
   const result = run(['apply-plan', '--plan', plan, '--dry-run', '--allow-partial']);

--- a/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
@@ -44,6 +44,19 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'gemini-3.8-flash',
+      maxContext: 1048576,
+      maxTokens: 65536,
+      quoteMaxToken: 1000000,
+      vision: true,
+      audio: true,
+      video: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gemini-3.1-pro-preview-customtools',
       maxContext: 1000000,
       maxTokens: 64000,

--- a/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Gemini/index.ts
@@ -5,20 +5,7 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
-      model: 'gemini-3.5-flash',
-      maxContext: 1048576,
-      maxTokens: 65536,
-      quoteMaxToken: 1000000,
-      vision: true,
-      audio: true,
-      video: true,
-      reasoning: true,
-      reasoningEffort: true,
-      toolChoice: true
-    },
-    {
-      type: ModelTypeEnum.llm,
-      model: 'gemini-3.6-flash',
+      model: 'gemini-3.8-flash',
       maxContext: 1048576,
       maxTokens: 65536,
       quoteMaxToken: 1000000,
@@ -44,7 +31,20 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
-      model: 'gemini-3.8-flash',
+      model: 'gemini-3.6-flash',
+      maxContext: 1048576,
+      maxTokens: 65536,
+      quoteMaxToken: 1000000,
+      vision: true,
+      audio: true,
+      video: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'gemini-3.5-flash',
       maxContext: 1048576,
       maxTokens: 65536,
       quoteMaxToken: 1000000,

--- a/packages/infrastructure/src/static-data/models/provider/SparkDesk/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/SparkDesk/index.ts
@@ -74,6 +74,18 @@ const models: ProviderConfigType = {
       reasoning: false,
       reasoningEffort: false,
       toolChoice: false
+    },
+    {
+      type: ModelTypeEnum.llm,
+      model: 'spark-x',
+      maxContext: 262144,
+      maxTokens: 262144,
+      quoteMaxToken: 250000,
+      maxTemperature: 2,
+      vision: false,
+      reasoning: true,
+      reasoningEffort: false,
+      toolChoice: true
     }
   ]
 };

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -36,6 +36,19 @@ describe('static model multimodal capabilities', () => {
     expect(llms.every((model) => model.vision && model.audio && model.video)).toBe(true);
   });
 
+  it('marks Gemini 3.8 Flash with its documented limits and agent capabilities', () => {
+    expect(getModel('Gemini', 'gemini-3.8-flash')).toMatchObject({
+      maxContext: 1048576,
+      maxTokens: 65536,
+      vision: true,
+      audio: true,
+      video: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    });
+  });
+
   it('marks Qwen visual models with their video input capability', () => {
     expect(getModel('Qwen', 'qwen3.8-flash')).toMatchObject({
       maxContext: 1000000,

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -10,8 +10,9 @@ import chatglm from './ChatGLM';
 import doubao from './Doubao';
 import gemini from './Gemini';
 import qwen from './Qwen';
+import sparkdesk from './SparkDesk';
 
-const staticModelList = [chatglm, doubao, gemini, qwen].flatMap((provider) =>
+const staticModelList = [chatglm, doubao, gemini, qwen, sparkdesk].flatMap((provider) =>
   provider.list.map((model) =>
     ModelItemSchema.parse({
       ...model,
@@ -91,6 +92,16 @@ describe('static model multimodal capabilities', () => {
       video: true,
       reasoning: true,
       reasoningEffort: true,
+      toolChoice: true
+    });
+  });
+
+  it('marks Spark X2 with its reasoning and tool capabilities', () => {
+    expect(getModel('SparkDesk', 'spark-x')).toMatchObject({
+      maxContext: 262144,
+      maxTokens: 262144,
+      reasoning: true,
+      reasoningEffort: false,
       toolChoice: true
     });
   });

--- a/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
@@ -44,6 +44,14 @@ describe('static model provider ordering', () => {
     expect(firstQwen37Index).toBeGreaterThan(lastQwen38Index);
   });
 
+  it('places Gemini Flash models in descending version order', () => {
+    const gemini = providerConfigs.find(({ provider }) => provider === 'Gemini');
+    const modelIds = gemini?.list.map((model) => model.model) ?? [];
+    const flashModels = ['gemini-3.8-flash', 'gemini-3.7-flash', 'gemini-3.6-flash', 'gemini-3.5-flash'];
+
+    expect(modelIds.slice(0, flashModels.length)).toEqual(flashModels);
+  });
+
   it('places ChatGLM 5.3 models before 5.2 and 5.1 models', () => {
     const chatglm = providerConfigs.find(({ provider }) => provider === 'ChatGLM');
     const modelIds = chatglm?.list.map((model) => model.model) ?? [];


### PR DESCRIPTION
## Summary

- add the official Spark X2 model ID `spark-x` to the SparkDesk presets
- add the GA `gemini-3.8-flash` preset with its documented 1,048,576 input and 65,536 output token limits
- order Gemini Flash presets newest-first: 3.8, 3.7, 3.6, 3.5
- harden the model-provider audit skill so repository-wide scans cannot silently omit providers or model candidates

## Audit hardening

- Gemini 3.8 Flash exposed the failure mode: the model catalog lagged the September 2 release notes
- Gemini audits now check the model catalog, release notes, deprecations, and pricing together
- every registered provider must have a non-pending checked state
- every locally missing candidate must be added or explicitly skipped with a reason
- scoped audits require explicit `--allow-partial`; full audits must cover all 34 providers
- `insertBefore` separates clone source selection from newest-first display placement

## Validation

- `bun run test`: 46 files and 345 tests passed
- 9 model-provider audit behavior tests passed
- targeted provider tests: 43 tests passed
- skill structure validation passed
- all four configured Gemini official sources returned HTTP 200
- model plan dry-run/write and `git diff --check` passed
- `bun tsc --noEmit` reports only four pre-existing missing `zh-CN` fields in `packages/infrastructure/src/plugin/tool.impl.test.ts`