### PR TITLE
feat: refresh model provider presets

### DIFF
--- a/.codex/skills/model-provider-updater/references/provider_sources.json
+++ b/.codex/skills/model-provider-updater/references/provider_sources.json
@@ -144,8 +144,12 @@
     "notes": "Use PPIO official docs; verify the exact model page during each run."
   },
   "AntLing": {
-    "docs": ["https://developer.ant-ling.com/en/docs/models", "https://www.ant-ling.com/en/"],
-    "notes": "Use Ant Ling developer docs and official model-family pages."
+    "docs": [
+      "https://developer.ant-ling.com/en/docs/models",
+      "https://developer.ant-ling.com/en/docs/models/deprecation/",
+      "https://www.ant-ling.com/en/"
+    ],
+    "notes": "Use Ant Ling developer docs, deprecation notices, and official model-family pages."
   },
   "Moka": {
     "docs": [],

--- a/.codex/skills/model-provider-updater/references/provider_sources.json
+++ b/.codex/skills/model-provider-updater/references/provider_sources.json
@@ -4,8 +4,11 @@
     "notes": "Use official OpenAI model docs or authenticated model-list API if credentials are explicitly available."
   },
   "Claude": {
-    "docs": ["https://platform.claude.com/docs/en/models/overview"],
-    "notes": "Anthropic documents current model IDs and aliases on the models page."
+    "docs": [
+      "https://platform.claude.com/docs/en/models/overview",
+      "https://platform.claude.com/docs/en/release-notes/overview"
+    ],
+    "notes": "Anthropic documents current model IDs and aliases on the models page; check release notes for newly launched models that may not yet appear throughout the catalog."
   },
   "Gemini": {
     "docs": [
@@ -17,16 +20,25 @@
     "notes": "Check the model catalog, release notes, deprecations, and pricing together because the catalog page can lag a newly released model. Use the official list-models API too when credentials are explicitly available."
   },
   "Grok": {
-    "docs": ["https://docs.x.ai/developers/models"],
-    "notes": "Use xAI model docs."
+    "docs": [
+      "https://docs.x.ai/developers/models",
+      "https://docs.x.ai/developers/release-notes"
+    ],
+    "notes": "Use xAI model docs and release notes together."
   },
   "MistralAI": {
-    "docs": ["https://docs.mistral.ai/models"],
-    "notes": "Use Mistral model overview and API docs."
+    "docs": [
+      "https://docs.mistral.ai/models",
+      "https://docs.mistral.ai/resources/changelogs"
+    ],
+    "notes": "Use Mistral model overview and changelog together."
   },
   "Qwen": {
-    "docs": ["https://help.aliyun.com/zh/model-studio/models"],
-    "notes": "Use Alibaba Cloud Model Studio model docs."
+    "docs": [
+      "https://help.aliyun.com/zh/model-studio/models",
+      "https://help.aliyun.com/zh/model-studio/newly-released-models"
+    ],
+    "notes": "Use Alibaba Cloud Model Studio model docs and release ledger together."
   },
   "Doubao": {
     "docs": ["https://www.volcengine.com/docs/82379/2549861?lang=zh"],
@@ -57,8 +69,11 @@
     "notes": "Use iFlytek Spark official docs."
   },
   "Hunyuan": {
-    "docs": ["https://cloud.tencent.com/document/product/1823/130051"],
-    "notes": "Use Tencent TokenHub's official Hy model docs."
+    "docs": [
+      "https://cloud.tencent.com/document/product/1823/130051",
+      "https://cloud.tencent.com/document/product/1823/130675"
+    ],
+    "notes": "Use Tencent TokenHub's official Hy model docs and product updates together."
   },
   "Baichuan": {
     "docs": ["https://platform.baichuan-ai.com/docs"],

--- a/packages/infrastructure/src/static-data/models/provider/Hunyuan/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/Hunyuan/index.ts
@@ -5,6 +5,19 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'hy4-preview',
+      maxContext: 1024000,
+      maxTokens: 64000,
+      quoteMaxToken: 960000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object', 'json_schema'],
+      vision: false,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'hy3',
       maxContext: 256000,
       maxTokens: 128000,

--- a/packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts
@@ -198,6 +198,18 @@ const models: ProviderConfigType = {
     },
     {
       type: ModelTypeEnum.llm,
+      model: 'gpt-5.3-codex',
+      maxContext: 400000,
+      maxTokens: 128000,
+      quoteMaxToken: 350000,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gpt-5.2',
       maxContext: 400000,
       maxTokens: 128000,

--- a/packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/OpenAI/index.ts
@@ -64,6 +64,18 @@ const models: ProviderConfigType = {
   list: [
     {
       type: ModelTypeEnum.llm,
+      model: 'gpt-6-astra',
+      maxContext: 1050000,
+      maxTokens: 128000,
+      quoteMaxToken: 1000000,
+      responseFormatList: ['text', 'json_schema'],
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'gpt-5.6',
       maxContext: 1050000,
       maxTokens: 128000,

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -123,6 +123,18 @@ describe('static model multimodal capabilities', () => {
     });
   });
 
+  it('marks GPT-5.3 Codex with its documented limits and coding capabilities', () => {
+    expect(getModel('OpenAI', 'gpt-5.3-codex')).toMatchObject({
+      maxContext: 400000,
+      maxTokens: 128000,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      responseFormatList: ['text', 'json_schema']
+    });
+  });
+
   it('marks Hy4 preview with its documented limits and agent capabilities', () => {
     expect(getModel('Hunyuan', 'hy4-preview')).toMatchObject({
       maxContext: 1024000,

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -9,10 +9,12 @@ import {
 import chatglm from './ChatGLM';
 import doubao from './Doubao';
 import gemini from './Gemini';
+import hunyuan from './Hunyuan';
+import openai from './OpenAI';
 import qwen from './Qwen';
 import sparkdesk from './SparkDesk';
 
-const staticModelList = [chatglm, doubao, gemini, qwen, sparkdesk].flatMap((provider) =>
+const staticModelList = [chatglm, doubao, gemini, hunyuan, openai, qwen, sparkdesk].flatMap((provider) =>
   provider.list.map((model) =>
     ModelItemSchema.parse({
       ...model,
@@ -106,6 +108,30 @@ describe('static model multimodal capabilities', () => {
       reasoning: true,
       reasoningEffort: true,
       toolChoice: true
+    });
+  });
+
+  it('marks GPT-6 Astra with its documented limits and agent capabilities', () => {
+    expect(getModel('OpenAI', 'gpt-6-astra')).toMatchObject({
+      maxContext: 1050000,
+      maxTokens: 128000,
+      vision: true,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      responseFormatList: ['text', 'json_schema']
+    });
+  });
+
+  it('marks Hy4 preview with its documented limits and agent capabilities', () => {
+    expect(getModel('Hunyuan', 'hy4-preview')).toMatchObject({
+      maxContext: 1024000,
+      maxTokens: 64000,
+      vision: false,
+      reasoning: true,
+      reasoningEffort: true,
+      toolChoice: true,
+      responseFormatList: ['text', 'json_object', 'json_schema']
     });
   });
 

--- a/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
@@ -60,6 +60,14 @@ describe('static model provider ordering', () => {
     expect(hunyuan?.list[0]?.model).toBe('hy4-preview');
   });
 
+  it('places GPT-5.3 Codex before GPT-5.2', () => {
+    const openai = providerConfigs.find(({ provider }) => provider === 'OpenAI');
+    const modelIds = openai?.list.map((model) => model.model) ?? [];
+
+    expect(modelIds.indexOf('gpt-5.3-codex')).toBeGreaterThanOrEqual(0);
+    expect(modelIds.indexOf('gpt-5.2')).toBeGreaterThan(modelIds.indexOf('gpt-5.3-codex'));
+  });
+
   it('places ChatGLM 5.3 models before 5.2 and 5.1 models', () => {
     const chatglm = providerConfigs.find(({ provider }) => provider === 'ChatGLM');
     const modelIds = chatglm?.list.map((model) => model.model) ?? [];

--- a/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
@@ -52,6 +52,14 @@ describe('static model provider ordering', () => {
     expect(modelIds.slice(0, flashModels.length)).toEqual(flashModels);
   });
 
+  it('places the newest OpenAI and Hunyuan models first', () => {
+    const openai = providerConfigs.find(({ provider }) => provider === 'OpenAI');
+    const hunyuan = providerConfigs.find(({ provider }) => provider === 'Hunyuan');
+
+    expect(openai?.list[0]?.model).toBe('gpt-6-astra');
+    expect(hunyuan?.list[0]?.model).toBe('hy4-preview');
+  });
+
   it('places ChatGLM 5.3 models before 5.2 and 5.1 models', () => {
     const chatglm = providerConfigs.find(({ provider }) => provider === 'ChatGLM');
     const modelIds = chatglm?.list.map((model) => model.model) ?? [];


### PR DESCRIPTION
## Summary
- Add OpenAI `gpt-6-astra` with its documented 1,050,000-token context window, 128,000-token output limit, vision input, reasoning effort, structured output, and tool calling capabilities.
- Add OpenAI `gpt-5.3-codex` with its documented 400,000-token context window, 128,000-token output limit, vision input, reasoning effort, structured output, and tool calling capabilities.
- Add Tencent Hunyuan `hy4-preview` with its documented 1,024k context window, 64k output limit, reasoning effort, structured output, and tool calling capabilities.
- Add regression coverage for capabilities and newest-first provider ordering.
- Expand audit source hints with official release-note, deprecation, and pricing pages for time-sensitive checks, including Ant Ling's model retirement ledger.

## Audit
- Reconciled all 34 registered providers against the configured official sources through 2026-09-07.
- Applied the add-only policy; no existing presets were removed.
- No additional general LLM preset was eligible on 2026-09-07; the latest catalog additions were already present or were specialized media/audio models.
- Recorded Ant Ling `Ling-2.5-1T` and `Ring-2.5-1T` as retirement-only IDs instead of adding or removing presets.
- Excluded specialized media/audio/OCR/security models, limited-access aliases, dated snapshots, dynamic catalog entries, and non-standalone orchestration systems from this general LLM refresh.

## Official evidence
- OpenAI GPT-6 Astra: https://developers.openai.com/api/docs/models/gpt-6-astra
- OpenAI GPT-5.3-Codex: https://developers.openai.com/api/docs/models/gpt-5.3-codex
- OpenAI latest-model guide: https://developers.openai.com/api/docs/guides/latest-model
- Tencent TokenHub model list: https://cloud.tencent.com/document/product/1823/130051
- Tencent Hy calling guide: https://cloud.tencent.com/document/product/1823/132252
- Tencent reasoning guide: https://cloud.tencent.com/document/product/1823/131208
- Ant Ling model deprecations: https://developer.ant-ling.com/en/docs/models/deprecation/

## Validation
- `node .codex/skills/model-provider-updater/scripts/model_provider_presets.mjs apply-plan --plan /private/tmp/model-provider-plan-20260907.json --dry-run` — passed, 34/34 providers audited.
- Model audit helper tests — 9 tests passed.
- `bun run test` — 46 files / 351 tests passed. Existing warnings note absent optional `.env.test` and `.env.test.local` files.
- `bun tsc --noEmit` — blocked by four pre-existing `zh-CN` fixture errors in `packages/infrastructure/src/plugin/tool.impl.test.ts`; this branch does not modify that file.
