### PR TITLE
feat: add Ant Ling Ling-3.0-flash-VL preset

### DIFF
--- a/.codex/skills/model-provider-updater/references/provider_sources.json
+++ b/.codex/skills/model-provider-updater/references/provider_sources.json
@@ -147,9 +147,10 @@
     "docs": [
       "https://developer.ant-ling.com/en/docs/models",
       "https://developer.ant-ling.com/en/docs/models/deprecation/",
+      "https://developer.ant-ling.com/en/docs/getting-started/changelog/",
       "https://www.ant-ling.com/en/"
     ],
-    "notes": "Use Ant Ling developer docs, deprecation notices, and official model-family pages."
+    "notes": "Use Ant Ling developer docs, changelog, deprecation notices, and official model-family pages."
   },
   "Moka": {
     "docs": [],

--- a/packages/infrastructure/src/static-data/models/provider/AntLing/index.ts
+++ b/packages/infrastructure/src/static-data/models/provider/AntLing/index.ts
@@ -6,6 +6,20 @@ const models: ProviderConfigType = {
     // Ling series - general language models
     {
       type: ModelTypeEnum.llm,
+      model: 'Ling-3.0-flash-VL',
+      maxContext: 256000,
+      maxTokens: 102400,
+      quoteMaxToken: 240000,
+      maxTemperature: 1,
+      responseFormatList: ['text', 'json_object', 'json_schema'],
+      vision: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true,
+      video: true
+    },
+    {
+      type: ModelTypeEnum.llm,
       model: 'Ling-3.0-flash',
       maxContext: 256000,
       maxTokens: 16000,

--- a/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/multimodal-capabilities.test.ts
@@ -6,6 +6,7 @@ import {
   ModelTypeEnum
 } from '@domain/entities/model.entity';
 
+import antling from './AntLing';
 import chatglm from './ChatGLM';
 import doubao from './Doubao';
 import gemini from './Gemini';
@@ -14,7 +15,7 @@ import openai from './OpenAI';
 import qwen from './Qwen';
 import sparkdesk from './SparkDesk';
 
-const staticModelList = [chatglm, doubao, gemini, hunyuan, openai, qwen, sparkdesk].flatMap((provider) =>
+const staticModelList = [antling, chatglm, doubao, gemini, hunyuan, openai, qwen, sparkdesk].flatMap((provider) =>
   provider.list.map((model) =>
     ModelItemSchema.parse({
       ...model,
@@ -28,6 +29,19 @@ const getModel = (provider: string, model: string) =>
   staticModelList.find((item) => item.provider === provider && item.model === model);
 
 describe('static model multimodal capabilities', () => {
+  it('marks Ant Ling Ling-3.0-flash-VL with its documented multimodal limits', () => {
+    expect(getModel('AntLing', 'Ling-3.0-flash-VL')).toMatchObject({
+      maxContext: 256000,
+      maxTokens: 102400,
+      responseFormatList: ['text', 'json_object', 'json_schema'],
+      vision: true,
+      video: true,
+      reasoning: false,
+      reasoningEffort: false,
+      toolChoice: true
+    });
+  });
+
   it('marks Gemini LLMs as supporting image, audio, and video inputs', () => {
     const llms = staticModelList.filter(
       (item): item is LLMModelItemType =>

--- a/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
+++ b/packages/infrastructure/src/static-data/models/provider/provider-order.test.ts
@@ -60,6 +60,12 @@ describe('static model provider ordering', () => {
     expect(hunyuan?.list[0]?.model).toBe('hy4-preview');
   });
 
+  it('places the newest Ant Ling model first', () => {
+    const antling = providerConfigs.find(({ provider }) => provider === 'AntLing');
+
+    expect(antling?.list[0]?.model).toBe('Ling-3.0-flash-VL');
+  });
+
   it('places GPT-5.3 Codex before GPT-5.2', () => {
     const openai = providerConfigs.find(({ provider }) => provider === 'OpenAI');
     const modelIds = openai?.list.map((model) => model.model) ?? [];


### PR DESCRIPTION
## Summary

- Audited all 34 registered model providers against their configured official catalogs on 2026-09-09.
- Added the stable `Ling-3.0-flash-VL` preset before `Ling-3.0-flash`.
- Preserved the add-only policy: no existing presets were removed.
- Added the Ant Ling changelog URL to the updater source hints.

## Model evidence

Ant Ling's official [changelog](https://developer.ant-ling.com/en/docs/getting-started/changelog/) released `Ling-3.0-flash-VL` on 2026-09-04. The official [multimodal guide](https://developer.ant-ling.com/en/docs/tutorials/multimodal-understanding/) documents text, image, and video input, and the [OpenAI-compatible API docs](https://developer.ant-ling.com/en/docs/api-reference/openai/) document the model's API availability.

The preset records a 256K context window, 102,400 max output tokens, image/video support, structured response formats, and tool calling. It does not enable reasoning because the API docs scope thinking to `Ling-3.0-flash` rather than the VL model.

## Validation

- `apply-plan --dry-run`: 34/34 providers audited; all `remove` arrays empty.
- Source hint check: 45 official URLs checked; 43 returned 200, SparkDesk was access-limited, and Moka/Other have no configured source hints.
- Targeted model tests: 50/50 passed.
- Full test suite: 46 files, 353 tests passed.
- `bun tsc --noEmit`: blocked by four pre-existing missing `zh-CN` fixtures in `packages/infrastructure/src/plugin/tool.impl.test.ts`; no errors point to this change.
